### PR TITLE
feature: Cast null option values to string for TypeScript compatibility

### DIFF
--- a/FrontEndApp/src/components/Settings/Bible/DownloadBibles.vue
+++ b/FrontEndApp/src/components/Settings/Bible/DownloadBibles.vue
@@ -28,7 +28,7 @@ const moduleTypeOptions = computed(() => {
         'ph4_mybible': 'PH4.org MyBible',
     };
     return [
-        { label: 'All sources', value: null },
+        { label: 'All sources', value: null as unknown as string },
         ...Array.from(types)
             .sort((a, b) => a.localeCompare(b))
             .map((type) => ({ label: labels[type] || type, value: type })),
@@ -45,7 +45,7 @@ const languageOptions = computed(() => {
         if (lang) langs.add(lang);
     }
     return [
-        { label: 'All languages', value: null },
+        { label: 'All languages', value: null as unknown as string },
         ...Array.from(langs)
             .sort((a, b) => a.localeCompare(b))
             .map((lang) => ({ label: lang.charAt(0).toUpperCase() + lang.slice(1), value: lang })),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "believers-sword-nightly",
   "description": "Believers Sword is an application for believers community, it is used to study bible, also used for praying, social or connect with other believers.",
   "author": "JenuelDev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "./dist/main.js",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
This pull request makes minor improvements to type safety in the Bible download settings component and bumps the application version. The most notable changes are:

Type safety improvements in filter options:

* Updated the `value` property for the "All sources" and "All languages" options in the `moduleTypeOptions` and `languageOptions` computed properties to explicitly cast `null` as `unknown as string`, ensuring better type compatibility and preventing potential type errors in TypeScript (`DownloadBibles.vue`). [[1]](diffhunk://#diff-a4fa6a4f057e0f692670fe3f209bb9cf6b4e8c17698fdd3b06347e67fc577d8cL31-R31) [[2]](diffhunk://#diff-a4fa6a4f057e0f692670fe3f209bb9cf6b4e8c17698fdd3b06347e67fc577d8cL48-R48)

Version update:

* Incremented the application version from `1.2.0` to `1.2.1` in `package.json` to reflect the latest changes.