### PR TITLE
Expand devotionals database with many entries

### DIFF
--- a/Electron/Setups/Setup/StoreDB/devotionals-data.json
+++ b/Electron/Setups/Setup/StoreDB/devotionals-data.json
@@ -1,615 +1,3655 @@
 {
-    "version": 2,
-    "devotionals": [
-        {
-            "day_number": 91,
-            "title": "A New Season of Hope",
-            "pause": "<p>Take a deep breath. Let the worries of yesterday fade. God is doing something new in your life today. Be still and know that He is God.</p>",
-            "listen": "<p>\"See, I am doing a new thing! Now it springs up; do you not perceive it? I am making a way in the wilderness and streams in the wasteland.\"</p><span class=\"verse-ref\">Isaiah 43:19</span>",
-            "think": "<p>April marks a season of renewal. Trees bud, flowers bloom, and creation itself declares that God specializes in making all things new. Whatever barren season you have walked through, God is faithful to bring forth life again.</p><p>The same God who commands spring to come after winter is working behind the scenes in your life. Trust His timing. The new thing He promised is already springing up.</p>",
-            "pray": "<p>Lord, open my eyes to see the new things You are doing in my life. Help me trust Your timing even when the season feels long. I choose to believe that You are making a way where there seems to be none. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Write down one area of your life where you need God to do something new. Place it somewhere visible and pray over it this week.</p>",
-            "verses": "[\"Isaiah:43:19\",\"Lamentations:3:22-23\",\"Revelation:21:5\"]"
-        },
-        {
-            "day_number": 92,
-            "title": "The Power of the Resurrection",
-            "pause": "<p>Close your eyes. Picture the empty tomb on that first Easter morning. The stone rolled away. Death defeated. Let that reality sink deep into your heart.</p>",
-            "listen": "<p>\"I want to know Christ — yes, to know the power of his resurrection and participation in his sufferings, becoming like him in his death, and so, somehow, attaining to the resurrection from the dead.\"</p><span class=\"verse-ref\">Philippians 3:10-11</span>",
-            "think": "<p>Paul did not merely want to know about the resurrection — he wanted to <em>experience</em> its power in his daily life. The same power that raised Jesus from the dead lives inside every believer. This is not a distant theological concept; it is a present reality.</p><p>When you face impossible situations, remember: you carry resurrection power within you. The God who conquered the grave is more than able to handle whatever you are walking through today.</p>",
-            "pray": "<p>Father, I want to know the power of Christ's resurrection in my everyday life. Strengthen me by Your Spirit. Let the same power that raised Jesus from the dead work mightily in me today. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Identify one area where you feel defeated or hopeless. Speak the truth of the resurrection over it: \"The same power that raised Christ from the dead is alive in me.\"</p>",
-            "verses": "[\"Philippians:3:10\",\"Ephesians:1:19-20\",\"Romans:8:11\"]"
-        },
-        {
-            "day_number": 93,
-            "title": "Walking in Newness of Life",
-            "pause": "<p>Be still for a moment. You are not who you used to be. In Christ, you are a new creation. Let that truth settle in your spirit.</p>",
-            "listen": "<p>\"Therefore, if anyone is in Christ, the new creation has come: The old has gone, the new is here!\"</p><span class=\"verse-ref\">2 Corinthians 5:17</span>",
-            "think": "<p>When you gave your life to Christ, something radical happened — your old identity died, and a brand-new you was born. You are not a cleaned-up version of your former self. You are an entirely new creation with a new nature, a new purpose, and a new destiny.</p><p>Stop looking in the rearview mirror at who you were. God is not holding your past against you. Walk boldly into the newness of life He has prepared for you.</p>",
-            "pray": "<p>Jesus, thank You for making me new. Help me to stop living as though my old identity still defines me. I receive my new identity in You. Teach me to walk in the fullness of the new creation I have become. Amen.</p>",
-            "go_action": "<p>Write down three things that are true about your new identity in Christ. Speak them aloud over yourself today.</p>",
-            "verses": "[\"2 Corinthians:5:17\",\"Romans:6:4\",\"Galatians:2:20\"]"
-        },
-        {
-            "day_number": 94,
-            "title": "He Carried Our Sorrows",
-            "pause": "<p>Sit quietly with God. If there is pain or grief in your heart, you do not need to hide it. He already knows, and He cares deeply.</p>",
-            "listen": "<p>\"Surely he took up our pain and bore our suffering, yet we considered him punished by God, stricken by him, and afflicted. But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.\"</p><span class=\"verse-ref\">Isaiah 53:4-5</span>",
-            "think": "<p>Jesus did not merely observe our suffering from a distance. He entered into it fully. On the cross, He took upon Himself every sorrow, every sickness, every sin that weighs us down. He was crushed so that we could be made whole.</p><p>If you are carrying grief or pain today, know that Jesus has already carried it for you. You do not have to bear it alone. Lay your burdens at the foot of the cross and receive the peace that His sacrifice purchased for you.</p>",
-            "pray": "<p>Lord Jesus, thank You for carrying my pain and sorrows on the cross. I lay every burden at Your feet right now. I receive the healing and peace that Your wounds have purchased for me. Amen.</p>",
-            "go_action": "<p>Is there a sorrow you have been carrying alone? Tell God about it honestly in prayer, and then write down: \"Jesus has carried this for me.\"</p>",
-            "verses": "[\"Isaiah:53:4-5\",\"1 Peter:2:24\",\"Matthew:11:28\"]"
-        },
-        {
-            "day_number": 95,
-            "title": "The Lamb Who Was Slain",
-            "pause": "<p>Take a moment to reflect on the magnitude of God's love. Before the foundation of the world, He already had a plan to rescue you.</p>",
-            "listen": "<p>\"For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your ancestors, but with the precious blood of Christ, a lamb without blemish or defect.\"</p><span class=\"verse-ref\">1 Peter 1:18-19</span>",
-            "think": "<p>Your redemption was not cheap. It cost the precious blood of the spotless Lamb of God. No amount of silver or gold could buy your freedom — only the sinless life of Jesus was sufficient to pay the price for your salvation.</p><p>When you begin to doubt your worth, remember the price that was paid for you. God did not spare His own Son because He considered you worth the sacrifice. You are that valuable to Him.</p>",
-            "pray": "<p>Father, I stand in awe of the price You paid for my redemption. Thank You for not sparing Your own Son but giving Him freely for me. Help me to live in a way that honors the precious blood of Jesus. Amen.</p>",
-            "go_action": "<p>Spend five minutes meditating on the cost of your salvation. Let gratitude fill your heart and shape how you treat others today.</p>",
-            "verses": "[\"1 Peter:1:18-19\",\"Revelation:5:12\",\"John:1:29\"]"
-        },
-        {
-            "day_number": 96,
-            "title": "From Darkness to Marvelous Light",
-            "pause": "<p>Close your eyes. Remember where you were before Christ found you. Now open them. Thank God for the light He has brought into your life.</p>",
-            "listen": "<p>\"But you are a chosen people, a royal priesthood, a holy nation, God's special possession, that you may declare the praises of him who called you out of darkness into his wonderful light.\"</p><span class=\"verse-ref\">1 Peter 2:9</span>",
-            "think": "<p>You were not pulled from darkness by accident. God <em>chose</em> you. He called you by name and brought you out of the shadows into His marvelous light. You are not a bystander in God's story — you are His special possession, set apart for a holy purpose.</p><p>Your identity is not based on your performance. You are chosen, royal, holy, and treasured. Let that truth define how you see yourself and how you walk through this day.</p>",
-            "pray": "<p>God, thank You for choosing me and calling me out of darkness. I receive my identity as Your special possession. Help me to walk as a child of light today and declare Your praises in everything I do. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Share your testimony with someone today — even a brief word about how God brought light into your darkness.</p>",
-            "verses": "[\"1 Peter:2:9\",\"Ephesians:5:8\",\"Colossians:1:13\"]"
-        },
-        {
-            "day_number": 97,
-            "title": "The Stone That Was Rolled Away",
-            "pause": "<p>Breathe deeply. Think of a situation in your life that feels sealed shut, like a stone blocking the way. Invite God into that space.</p>",
-            "listen": "<p>\"When they looked up, they saw that the stone, which was very large, had been rolled away.\"</p><span class=\"verse-ref\">Mark 16:4</span>",
-            "think": "<p>The women who went to the tomb that Sunday morning were worried about who would roll away the stone. It was massive, immovable by human strength. But when they arrived, the work was already done. God had moved the stone before they even got there.</p><p>Are you worried about obstacles that seem too big to move? God is already working ahead of you. The stone you are stressing about may already be rolled away by the time you arrive. Trust Him.</p>",
-            "pray": "<p>Lord, I bring You the stones in my life — the obstacles that feel immovable. I trust that You are already working ahead of me. Give me faith to keep walking forward, knowing that You will make a way. Amen.</p>",
-            "go_action": "<p>Name your \"stone\" — the biggest obstacle you face right now. Release it to God and take one step of faith toward it today.</p>",
-            "verses": "[\"Mark:16:4\",\"Matthew:28:2\",\"Luke:1:37\"]"
-        },
-        {
-            "day_number": 98,
-            "title": "Do Not Be Afraid",
-            "pause": "<p>Let your shoulders relax. Release the tension in your body. Hear the angel's words echo across the centuries: \"Do not be afraid.\"</p>",
-            "listen": "<p>\"The angel said to the women, 'Do not be afraid, for I know that you are looking for Jesus, who was crucified. He is not here; he has risen, just as he said.'\"</p><span class=\"verse-ref\">Matthew 28:5-6</span>",
-            "think": "<p>Fear is a natural human response to uncertainty. The women at the tomb were terrified. But the angel's first words were not a rebuke — they were comfort. God meets us in our fear with reassurance, not condemnation.</p><p>Whatever makes you afraid today — an uncertain future, a health concern, a broken relationship — hear God say to you: \"Do not be afraid.\" The One who conquered death is with you. There is nothing you will face that He has not already overcome.</p>",
-            "pray": "<p>Father, I confess my fears to You. I choose to trust the risen Christ rather than my circumstances. Replace my fear with faith, my anxiety with peace, and my doubt with confidence in Your promises. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Every time fear rises today, pause and whisper: \"He is risen. I do not need to be afraid.\"</p>",
-            "verses": "[\"Matthew:28:5-6\",\"Isaiah:41:10\",\"2 Timothy:1:7\"]"
-        },
-        {
-            "day_number": 99,
-            "title": "The Garden and the Tomb",
-            "pause": "<p>Imagine yourself in a quiet garden at dawn. The air is cool, the birds are beginning to sing. Jesus is near. Rest in His presence.</p>",
-            "listen": "<p>\"Now Mary stood outside the tomb crying... She turned around and saw Jesus standing there, but she did not realize that it was Jesus. He asked her, 'Woman, why are you crying? Who is it you are looking for?'\"</p><span class=\"verse-ref\">John 20:11,14-15</span>",
-            "think": "<p>Mary Magdalene came to the tomb weeping, certain that all hope was lost. She was so consumed by grief that she did not recognize Jesus standing right in front of her. It was only when He spoke her name that her eyes were opened.</p><p>Sometimes our pain can blind us to God's presence. He is closer than you think — often standing right beside you in your darkest moment. Listen for His voice. He knows your name, and He is calling you out of sorrow into joy.</p>",
-            "pray": "<p>Jesus, open my eyes to see You even in the midst of my tears. Speak my name and remind me that You are near. Turn my mourning into dancing and my sorrow into joy. Amen.</p>",
-            "go_action": "<p>Find a quiet place today — even five minutes — and simply listen for God's voice. He may speak through Scripture, a thought, or a deep sense of peace.</p>",
-            "verses": "[\"John:20:11-16\",\"Psalm:30:5\",\"Isaiah:61:3\"]"
-        },
-        {
-            "day_number": 100,
-            "title": "Alive Forevermore",
-            "pause": "<p>This is day 100. A milestone in this year's journey with God. Pause and thank Him for every step that has brought you here.</p>",
-            "listen": "<p>\"I am the Living One; I was dead, and now look, I am alive for ever and ever! And I hold the keys of death and Hades.\"</p><span class=\"verse-ref\">Revelation 1:18</span>",
-            "think": "<p>Jesus is not a historical figure who lived and died two thousand years ago. He is the Living One — alive right now, reigning in glory, holding the keys of death and the grave. No other religious leader can make this claim. The tomb is empty, and our Savior lives.</p><p>Because He lives, we can face tomorrow. Because He holds the keys, death has no power over us. Every fear, every enemy, every obstacle is subject to the One who is alive forevermore.</p>",
-            "pray": "<p>Jesus, You are alive! I worship You as the Living One who holds all authority. Because You live, I have hope. Because You reign, I have peace. Thank You for the assurance of eternal life. Amen.</p>",
-            "go_action": "<p>Celebrate this milestone. Tell someone today: \"Jesus is alive, and that changes everything.\"</p>",
-            "verses": "[\"Revelation:1:18\",\"John:11:25\",\"Romans:6:9\"]"
-        },
-        {
-            "day_number": 101,
-            "title": "Doubts Do Not Disqualify You",
-            "pause": "<p>If you have ever wrestled with doubt, you are in good company. Even the disciples doubted. Come as you are — God welcomes honest questions.</p>",
-            "listen": "<p>\"Then he said to Thomas, 'Put your finger here; see my hands. Reach out your hand and put it into my side. Stop doubting and believe.' Thomas said to him, 'My Lord and my God!'\"</p><span class=\"verse-ref\">John 20:27-28</span>",
-            "think": "<p>Jesus did not reject Thomas for doubting. Instead, He met Thomas exactly where he was and offered the evidence he needed. God is not threatened by your questions. He is big enough to handle your doubts and patient enough to walk you through them.</p><p>Notice that Thomas's doubt, once met by the risen Christ, produced one of the most powerful confessions of faith in all of Scripture: \"My Lord and my God!\" Your wrestle with doubt may be the very thing that leads you to a deeper faith.</p>",
-            "pray": "<p>Lord, I bring my doubts and questions to You honestly. Meet me where I am. Strengthen my faith and help me to see You clearly. Like Thomas, I want to say with my whole heart: \"My Lord and my God!\" Amen.</p>",
-            "go_action": "<p>Write down one doubt or question you have been afraid to bring to God. Bring it to Him in prayer today — He is not offended by your honesty.</p>",
-            "verses": "[\"John:20:27-28\",\"Mark:9:24\",\"Jude:1:22\"]"
-        },
-        {
-            "day_number": 102,
-            "title": "The Road to Emmaus",
-            "pause": "<p>Think about a time when you were discouraged and confused about God's plan. Even in those moments, Jesus was walking beside you.</p>",
-            "listen": "<p>\"As they talked and discussed these things with each other, Jesus himself came up and walked along with them; but they were kept from recognizing him.\"</p><span class=\"verse-ref\">Luke 24:15-16</span>",
-            "think": "<p>Two disciples walked the road to Emmaus, heartbroken and confused after the crucifixion. They had hoped Jesus was the Messiah, but now He was dead. What they did not realize was that the risen Jesus was walking right beside them, patiently listening and teaching.</p><p>In your seasons of confusion, Jesus is not absent — He is present, walking alongside you. He may reveal Himself in unexpected ways: through Scripture, through a friend, or through a sudden moment of clarity. Keep walking and keep your heart open.</p>",
-            "pray": "<p>Jesus, even when I cannot see You or feel You, I choose to believe You are walking with me. Open my eyes to recognize Your presence on the road. Set my heart on fire with Your Word. Amen.</p>",
-            "go_action": "<p>Go for a walk today — even a short one — and talk to Jesus as if He were walking right beside you. He is.</p>",
-            "verses": "[\"Luke:24:15-16\",\"Luke:24:32\",\"Matthew:28:20\"]"
-        },
-        {
-            "day_number": 103,
-            "title": "Peace Be With You",
-            "pause": "<p>Inhale slowly. Exhale. Receive the peace of Christ. It is not the absence of trouble — it is the presence of God in the midst of trouble.</p>",
-            "listen": "<p>\"On the evening of that first day of the week, when the disciples were together, with the doors locked for fear of the Jewish leaders, Jesus came and stood among them and said, 'Peace be with you!'\"</p><span class=\"verse-ref\">John 20:19</span>",
-            "think": "<p>The disciples were hiding behind locked doors, paralyzed by fear. But locked doors are no obstacle for the risen Christ. He walked right through them and spoke peace into their terror. His first word to frightened people was not a command — it was a gift: <em>peace</em>.</p><p>No matter how tightly you have locked the doors of your heart out of fear, Jesus can reach you. He comes not to judge you for being afraid, but to fill you with a peace that the world cannot give and cannot take away.</p>",
-            "pray": "<p>Prince of Peace, I open the locked doors of my heart to You. Come in and fill every fearful corner with Your presence. I receive Your peace — not as the world gives, but as only You can give. Amen.</p>",
-            "go_action": "<p>Is there someone in your life who needs to hear \"peace be with you\" today? Send them an encouraging message or call them.</p>",
-            "verses": "[\"John:20:19\",\"John:14:27\",\"Philippians:4:7\"]"
-        },
-        {
-            "day_number": 104,
-            "title": "Scars That Tell a Story",
-            "pause": "<p>Look at your hands. Every line, every mark tells a story. Jesus chose to keep His scars. They are proof of a love that conquered death.</p>",
-            "listen": "<p>\"Then he said to Thomas, 'Put your finger here; see my hands. Reach out your hand and put it into my side.'\"</p><span class=\"verse-ref\">John 20:27</span>",
-            "think": "<p>When Jesus rose from the dead, He could have had a completely new, unmarked body. Instead, He kept His scars. He showed them to His disciples as proof — not of defeat, but of victory. His wounds are evidence that love went all the way and won.</p><p>Your scars — the wounds from past pain, failures, and heartbreaks — are not signs of weakness. In God's hands, they become a testimony. They tell the story of what you survived by His grace. Do not be ashamed of them; they are part of your resurrection story.</p>",
-            "pray": "<p>Jesus, thank You for Your scars that purchased my healing. Help me see my own wounds not as reasons for shame, but as testimonies of Your faithfulness. Use my story to encourage others. Amen.</p>",
-            "go_action": "<p>Think of a scar — physical or emotional — that God has redeemed. Thank Him for turning your pain into a testimony.</p>",
-            "verses": "[\"John:20:27\",\"2 Corinthians:12:9\",\"Psalm:147:3\"]"
-        },
-        {
-            "day_number": 105,
-            "title": "Breakfast by the Shore",
-            "pause": "<p>Picture the Sea of Galilee at dawn. A charcoal fire on the beach. The smell of fresh bread and fish. Jesus is cooking breakfast for His friends.</p>",
-            "listen": "<p>\"Jesus said to them, 'Come and have breakfast.' None of the disciples dared ask him, 'Who are you?' They knew it was the Lord.\"</p><span class=\"verse-ref\">John 21:12</span>",
-            "think": "<p>After His resurrection, Jesus did not summon His disciples to a palace or a throne room. He met them on a beach and made them breakfast. The King of Kings served fish and bread to tired, confused fishermen. This is the heart of our God — present in the ordinary, meeting us in our everyday needs.</p><p>God cares about the mundane details of your life. He is not only the God of miracles and grand moments. He is the God of breakfast, of daily provision, of quiet companionship by the shore.</p>",
-            "pray": "<p>Lord, thank You for meeting me in the ordinary moments. Help me to recognize Your presence in the daily routines of life — in meals, in conversations, in quiet mornings. You are the God of the everyday. Amen.</p>",
-            "go_action": "<p>Prepare a meal for someone today — a friend, a family member, a neighbor. Let it be an act of love that mirrors the heart of Jesus.</p>",
-            "verses": "[\"John:21:12\",\"John:21:15-17\",\"Psalm:23:5\"]"
-        },
-        {
-            "day_number": 106,
-            "title": "Do You Love Me?",
-            "pause": "<p>Let God ask you the same question He asked Peter: \"Do you love Me?\" Do not rush to answer. Sit with it. Let it search your heart.</p>",
-            "listen": "<p>\"When they had finished eating, Jesus said to Simon Peter, 'Simon son of John, do you love me more than these?' 'Yes, Lord,' he said, 'you know that I love you.' Jesus said, 'Feed my lambs.'\"</p><span class=\"verse-ref\">John 21:15</span>",
-            "think": "<p>Peter had denied Jesus three times. Now, the risen Jesus gave him three opportunities to reaffirm his love. This was not an interrogation — it was restoration. Every \"Do you love Me?\" was an invitation to replace a denial with a declaration of love.</p><p>If you have failed God, He is not keeping score. He is offering you a fresh start. He does not ask for perfection — He asks for love. And each time you say \"yes\" to Him, He entrusts you with greater purpose: \"Feed my sheep.\"</p>",
-            "pray": "<p>Jesus, You know all things — You know that I love You, even imperfectly. Thank You for restoring me after my failures. I say yes to You again today. Show me how to serve others from the overflow of that love. Amen.</p>",
-            "go_action": "<p>Has failure made you feel disqualified? Write \"He restores me\" somewhere you will see it today. Then do something kind for someone as an act of renewed purpose.</p>",
-            "verses": "[\"John:21:15-17\",\"Psalm:51:12\",\"Lamentations:3:22-23\"]"
-        },
-        {
-            "day_number": 107,
-            "title": "The Promise of the Spirit",
-            "pause": "<p>Be still. The same Holy Spirit who empowered the early church lives within you right now. Acknowledge His presence.</p>",
-            "listen": "<p>\"But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"</p><span class=\"verse-ref\">Acts 1:8</span>",
-            "think": "<p>Before ascending to heaven, Jesus promised His followers something extraordinary: the Holy Spirit. Not a distant force, but a personal Presence who would empower them to do things beyond their natural ability. This promise was for them — and it is for you.</p><p>You are not meant to live the Christian life in your own strength. The Holy Spirit is your helper, your comforter, your guide, and your source of supernatural power. Lean into Him today.</p>",
-            "pray": "<p>Holy Spirit, fill me afresh today. I cannot live this life in my own strength. I need Your power, Your guidance, and Your comfort. Empower me to be a faithful witness wherever I go. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Before making any decision today, pause and ask the Holy Spirit: \"What would You have me do?\" Then listen.</p>",
-            "verses": "[\"Acts:1:8\",\"John:14:26\",\"Romans:8:26\"]"
-        },
-        {
-            "day_number": 108,
-            "title": "Seeds Must Fall and Die",
-            "pause": "<p>Hold a seed in your mind's eye — small, unremarkable, lifeless in appearance. Yet within it lies an entire harvest. Be patient with what God is growing in you.</p>",
-            "listen": "<p>\"Very truly I tell you, unless a kernel of wheat falls to the ground and dies, it remains only a single seed. But if it dies, it produces many seeds.\"</p><span class=\"verse-ref\">John 12:24</span>",
-            "think": "<p>Jesus spoke these words about His own death and resurrection, but the principle extends to our lives. Growth requires letting go. Fruitfulness requires dying to self — to our pride, our plans, our desire for control. It is in the surrendered places that God produces the greatest harvest.</p><p>The things you are releasing right now — comfort, certainty, old habits — are seeds being planted. Trust the process. What looks like death is actually the beginning of abundant new life.</p>",
-            "pray": "<p>Lord, give me the courage to let go of what You are asking me to release. I trust that what dies in Your hands does not stay dead — it becomes a harvest. Help me surrender fully. Amen.</p>",
-            "go_action": "<p>Identify one thing God is asking you to let go of. Write it on a piece of paper, pray over it, and symbolically release it to God.</p>",
-            "verses": "[\"John:12:24\",\"Galatians:2:20\",\"Mark:8:35\"]"
-        },
-        {
-            "day_number": 109,
-            "title": "He Prepares a Table for You",
-            "pause": "<p>Rest. Even in the middle of your battles, God has set a table for you. You are invited to sit down and feast in His presence.</p>",
-            "listen": "<p>\"You prepare a table before me in the presence of my enemies. You anoint my head with oil; my cup overflows.\"</p><span class=\"verse-ref\">Psalm 23:5</span>",
-            "think": "<p>Notice where the table is set — not after the battle, but <em>in the presence of your enemies</em>. God does not wait until your problems are solved to bless you. He blesses you right in the middle of the struggle. His provision, peace, and abundance are available even in the fight.</p><p>The enemy wants you to believe you are starving and abandoned. But God has set a feast before you. Sit down. Eat. Let your cup overflow. The battle belongs to the Lord.</p>",
-            "pray": "<p>Good Shepherd, thank You for preparing a table for me even when enemies surround me. I choose to feast on Your goodness rather than focus on my problems. My cup overflows with Your blessings. Amen.</p>",
-            "go_action": "<p>Instead of worrying about a current problem, intentionally thank God for three specific blessings in your life right now.</p>",
-            "verses": "[\"Psalm:23:5\",\"Psalm:23:1-6\",\"Romans:8:37\"]"
-        },
-        {
-            "day_number": 110,
-            "title": "From Mourning to Dancing",
-            "pause": "<p>Think about a time when your heart was heavy. Now think about a time when joy returned. God is the One who turns our mourning into dancing.</p>",
-            "listen": "<p>\"You turned my wailing into dancing; you removed my sackcloth and clothed me with joy, that my heart may sing your praises and not be silent. Lord my God, I will praise you forever.\"</p><span class=\"verse-ref\">Psalm 30:11-12</span>",
-            "think": "<p>The resurrection is the ultimate picture of mourning turned to dancing. The disciples went from devastating grief on Friday to uncontainable joy on Sunday. God did not remove the pain — He transformed it. He walked them through it and brought them out the other side with something greater.</p><p>If you are in a season of weeping, hold on. Joy is coming. It may not come on your timeline, but it will come. God is faithful to complete the work He has started in you.</p>",
-            "pray": "<p>Father, I trust that You are turning my mourning into dancing. Even if I cannot see it yet, I believe that joy is on the way. Clothe me with gladness and let my heart sing Your praises. Amen.</p>",
-            "go_action": "<p>Put on a worship song and let yourself be moved. Sing, clap, or dance — even if it feels small. Choose joy today as an act of faith.</p>",
-            "verses": "[\"Psalm:30:11-12\",\"Jeremiah:31:13\",\"John:16:20\"]"
-        },
-        {
-            "day_number": 111,
-            "title": "The Cross Before the Crown",
-            "pause": "<p>Reflect on this: there is no crown without a cross, no victory without a battle, no resurrection without a crucifixion. God uses the hard places.</p>",
-            "listen": "<p>\"For the joy set before him he endured the cross, scorning its shame, and sat down at the right hand of the throne of God.\"</p><span class=\"verse-ref\">Hebrews 12:2</span>",
-            "think": "<p>Jesus endured the worst the world could throw at Him — betrayal, mockery, torture, death — because He could see beyond the cross to the joy that awaited. He kept His eyes on the eternal reward and endured the temporary suffering.</p><p>Your present difficulties are not the end of the story. Like Jesus, you can endure the hard season because there is joy set before you. Keep your eyes on what God has promised, not on what you are currently walking through.</p>",
-            "pray": "<p>Jesus, when the road is painful, help me to fix my eyes on You. Give me the strength to endure with grace, knowing that joy awaits on the other side. I trust Your process. Amen.</p>",
-            "go_action": "<p>Write Hebrews 12:2 on a card and place it where you will see it. Let it remind you that endurance leads to joy.</p>",
-            "verses": "[\"Hebrews:12:2\",\"James:1:2-4\",\"Romans:8:18\"]"
-        },
-        {
-            "day_number": 112,
-            "title": "Grafted Into the Vine",
-            "pause": "<p>Picture a vine with many branches, each one connected, each one alive because of the sap flowing from the root. You are one of those branches.</p>",
-            "listen": "<p>\"I am the vine; you are the branches. If you remain in me and I in you, you will bear much fruit; apart from me you can do nothing.\"</p><span class=\"verse-ref\">John 15:5</span>",
-            "think": "<p>A branch does not produce fruit by straining or trying harder. It produces fruit by staying connected to the vine. The life, the nutrients, the growth — all of it comes from the vine. The branch's only job is to remain attached.</p><p>In a world that prizes hustle and self-sufficiency, Jesus invites us to a different way: abide. Stay connected. Rest in Him. The fruit will come naturally as you remain in His love, His Word, and His presence.</p>",
-            "pray": "<p>Jesus, I want to remain in You. Forgive me for the times I have tried to produce fruit in my own strength. Teach me to abide in Your presence and trust You with the outcome. Amen.</p>",
-            "go_action": "<p>Choose one way to abide in Christ today: read a passage of Scripture slowly, spend time in prayer, or sit in silence with Him for ten minutes.</p>",
-            "verses": "[\"John:15:5\",\"John:15:4\",\"Galatians:5:22-23\"]"
-        },
-        {
-            "day_number": 113,
-            "title": "The Victory Is Already Won",
-            "pause": "<p>Take a breath. Whatever battle you are facing, the outcome has already been decided. In Christ, you are on the winning side.</p>",
-            "listen": "<p>\"But thanks be to God! He gives us the victory through our Lord Jesus Christ.\"</p><span class=\"verse-ref\">1 Corinthians 15:57</span>",
-            "think": "<p>The resurrection was God's ultimate declaration of victory. Death, sin, and the grave — humanity's greatest enemies — were defeated once and for all. This victory was not earned by our effort but given to us as a gift through Jesus Christ.</p><p>You do not fight <em>for</em> victory; you fight <em>from</em> victory. The battle has already been won on the cross. When you face temptation, discouragement, or spiritual attack, stand firm in the finished work of Christ. The enemy is already defeated.</p>",
-            "pray": "<p>Father, thank You for the victory You have already won. I do not fight from a place of fear but from a place of triumph. Help me stand firm in the truth that the battle is already Yours. In Jesus' name, Amen.</p>",
-            "go_action": "<p>Replace one negative, fearful thought today with this declaration: \"Thanks be to God, who gives me the victory through Jesus Christ.\"</p>",
-            "verses": "[\"1 Corinthians:15:57\",\"Romans:8:37\",\"1 John:5:4\"]"
-        },
-        {
-            "day_number": 114,
-            "title": "Springs of Living Water",
-            "pause": "<p>Think of a cool, flowing spring of water on a hot day. Let your soul be refreshed. Jesus offers water that never runs dry.</p>",
-            "listen": "<p>\"Whoever believes in me, as Scripture has said, rivers of living water will flow from within them.\"</p><span class=\"verse-ref\">John 7:38</span>",
-            "think": "<p>Jesus does not just quench your thirst — He turns you into a source of refreshment for others. The living water He gives is the Holy Spirit, flowing from within you like a river. It is not a trickle; it is an overflowing, life-giving stream.</p><p>When you abide in Christ, you naturally become a blessing to those around you. Your words bring encouragement. Your presence brings peace. Your life points others to the Source. You do not have to force it — just stay connected to the Spring.</p>",
-            "pray": "<p>Lord Jesus, let rivers of living water flow from within me. Fill me so full of Your Spirit that it overflows to everyone I encounter. Let my life be refreshing to others. Amen.</p>",
-            "go_action": "<p>Be a \"spring of living water\" today — offer a cold drink, a kind word, or practical help to someone who looks weary.</p>",
-            "verses": "[\"John:7:38\",\"John:4:14\",\"Isaiah:58:11\"]"
-        },
-        {
-            "day_number": 115,
-            "title": "He Makes All Things New",
-            "pause": "<p>Close your eyes. Think of something in your life that feels old, worn out, or broken. Now hear God whisper: \"I am making all things new.\"</p>",
-            "listen": "<p>\"He who was seated on the throne said, 'I am making everything new!' Then he said, 'Write this down, for these words are trustworthy and true.'\"</p><span class=\"verse-ref\">Revelation 21:5</span>",
-            "think": "<p>God does not just patch things up — He makes them <em>new</em>. Not repaired. Not refurbished. Brand new. This is the promise of the One who sits on the throne: total restoration, complete renewal, a future so beautiful that He told John to write it down because it is absolutely trustworthy.</p><p>That broken relationship, that shattered dream, that part of your life that feels beyond repair — God has not given up on it. He is the master Restorer, and He is working even now to bring beauty from ashes.</p>",
-            "pray": "<p>God, I believe Your promise to make all things new. I bring the broken areas of my life to You. Restore, renew, and rebuild what the enemy has tried to destroy. I trust Your faithful words. Amen.</p>",
-            "go_action": "<p>Take something broken — a strained friendship, a neglected goal, a forgotten dream — and take one small step toward renewal today.</p>",
-            "verses": "[\"Revelation:21:5\",\"Isaiah:61:3\",\"Joel:2:25\"]"
-        },
-        {
-            "day_number": 116,
-            "title": "Forgiven and Set Free",
-            "pause": "<p>Let go of the guilt. Let go of the shame. Christ has already paid the price. You are forgiven. Receive it.</p>",
-            "listen": "<p>\"Therefore, there is now no condemnation for those who are in Christ Jesus, because through Christ Jesus the law of the Spirit who gives life has set you free from the law of sin and death.\"</p><span class=\"verse-ref\">Romans 8:1-2</span>",
-            "think": "<p>No condemnation. Not \"less condemnation\" or \"condemnation on good days.\" <em>No</em> condemnation — none at all — for those who are in Christ. The gavel has come down, and the verdict is: free. The law of the Spirit of life has broken the chains of sin and death.</p><p>If the enemy whispers that you are still guilty, remind him of the cross. If your own heart condemns you, remember that God is greater than your heart. You are not defined by your worst moment. You are defined by Christ's best moment — His sacrifice for you.</p>",
-            "pray": "<p>Father, I receive Your forgiveness today. I refuse to live under condemnation when Christ has set me free. Help me to walk in the freedom You purchased for me and to extend that same grace to others. Amen.</p>",
-            "go_action": "<p>If you have been carrying guilt over a confessed sin, write it down and then cross it out. Write over it: \"No condemnation — Romans 8:1.\" Let it go.</p>",
-            "verses": "[\"Romans:8:1-2\",\"1 John:1:9\",\"Psalm:103:12\"]"
-        },
-        {
-            "day_number": 117,
-            "title": "The Good Shepherd Leads",
-            "pause": "<p>Sheep do not need to know the entire path. They only need to know the Shepherd's voice. Listen for His voice today.</p>",
-            "listen": "<p>\"My sheep listen to my voice; I know them, and they follow me. I give them eternal life, and they shall never perish; no one will snatch them out of my hand.\"</p><span class=\"verse-ref\">John 10:27-28</span>",
-            "think": "<p>Jesus describes a beautiful, intimate relationship between a shepherd and his sheep. He knows you — not just your name, but your heart, your struggles, your dreams. And you can know His voice — distinct, trustworthy, leading you to green pastures and still waters.</p><p>In a world full of competing voices, learn to distinguish the Shepherd's voice. He will never lead you into danger. He will never abandon you. And nothing — absolutely nothing — can snatch you from His hand.</p>",
-            "pray": "<p>Good Shepherd, tune my ears to Your voice above all the noise. I trust You to lead me on the right path. Thank You that I am secure in Your hand and that nothing can take me from You. Amen.</p>",
-            "go_action": "<p>Practice listening to God today. Before each major moment — a meeting, a conversation, a decision — ask: \"Shepherd, what do You want me to know?\"</p>",
-            "verses": "[\"John:10:27-28\",\"Psalm:23:1-3\",\"Isaiah:30:21\"]"
-        },
-        {
-            "day_number": 118,
-            "title": "Clothed in Righteousness",
-            "pause": "<p>Imagine removing heavy, dirty garments and being clothed in pure, white robes. This is what Christ has done for you. Receive it.</p>",
-            "listen": "<p>\"I delight greatly in the Lord; my soul rejoices in my God. For he has clothed me with garments of salvation and arrayed me in a robe of his righteousness.\"</p><span class=\"verse-ref\">Isaiah 61:10</span>",
-            "think": "<p>You cannot earn righteousness by your own efforts. It is a gift — a robe that God Himself wraps around you. When He looks at you, He does not see your failures and stains. He sees you clothed in the righteousness of Christ, beautiful and blameless.</p><p>Stop trying to clean yourself up before coming to God. He is the one who clothes you. Come as you are, and let Him dress you in salvation and righteousness. Then walk in the confidence that you are already accepted and loved.</p>",
-            "pray": "<p>Lord, I am grateful that my righteousness comes from You and not from my own works. Thank You for clothing me in salvation. Help me walk today in the confidence of who I am in Christ. Amen.</p>",
-            "go_action": "<p>The next time you feel \"not good enough,\" remember: you are clothed in His righteousness. Speak it: \"I am righteous in Christ — not by my works, but by His grace.\"</p>",
-            "verses": "[\"Isaiah:61:10\",\"2 Corinthians:5:21\",\"Philippians:3:9\"]"
-        },
-        {
-            "day_number": 119,
-            "title": "Hope That Does Not Disappoint",
-            "pause": "<p>Whatever has disappointed you — a broken promise, an unmet expectation, a delayed dream — know this: the hope God gives will never put you to shame.</p>",
-            "listen": "<p>\"And hope does not put us to shame, because God's love has been poured out into our hearts through the Holy Spirit, who has been given to us.\"</p><span class=\"verse-ref\">Romans 5:5</span>",
-            "think": "<p>Worldly hope is uncertain — it depends on circumstances, people, and timing. But the hope we have in Christ is anchored in something unshakeable: God's love, poured into our hearts by the Holy Spirit. This hope is not wishful thinking; it is confident expectation based on God's character.</p><p>Even when life disappoints, God never does. His promises are yes and amen in Christ. The hope He gives is not fragile — it is an anchor for the soul, firm and secure. Hold fast to it.</p>",
-            "pray": "<p>Father, pour out Your love afresh in my heart today. Anchor my hope in Your promises, not in my circumstances. Thank You that the hope You give will never disappoint. I trust You. Amen.</p>",
-            "go_action": "<p>Encourage someone who is losing hope today. Share a Bible verse or a word of encouragement. Be a carrier of the hope that does not disappoint.</p>",
-            "verses": "[\"Romans:5:5\",\"Hebrews:6:19\",\"Jeremiah:29:11\"]"
-        },
-        {
-            "day_number": 120,
-            "title": "Living as Resurrection People",
-            "pause": "<p>As this month draws to a close, sit with this truth: you serve a risen Savior. Because of the resurrection, everything has changed. You are alive in Christ.</p>",
-            "listen": "<p>\"Since, then, you have been raised with Christ, set your hearts on things above, where Christ is, seated at the right hand of God. Set your minds on things above, not on earthly things.\"</p><span class=\"verse-ref\">Colossians 3:1-2</span>",
-            "think": "<p>The resurrection is not just an event we celebrate once a year — it is a reality we live in every single day. Because Christ was raised, we too have been raised to new life. Our perspective should be shaped by eternity, not just by the temporary circumstances we see around us.</p><p>As resurrection people, we live with hope in despair, peace in chaos, joy in suffering, and love in hatred. We are citizens of heaven, living with purpose on earth. Let this truth shape every decision, every relationship, and every moment of this day.</p>",
-            "pray": "<p>Risen Lord, help me to live each day as a resurrection person. Set my heart and mind on things above. Let the reality of Your resurrection transform how I see the world and how I walk through it. In Your powerful name, Amen.</p>",
-            "go_action": "<p>Reflect on this month's journey through the resurrection theme. Write down the one truth that impacted you the most. Carry it into the months ahead.</p>",
-            "verses": "[\"Colossians:3:1-2\",\"Ephesians:2:6\",\"Romans:6:4\"]"
-        },
-        {
-            "day_number": 121,
-            "title": "Morning Mercies",
-            "pause": "<p>Before the noise of the day begins, be still. God has already met you here with fresh mercy.</p>",
-            "listen": "<p>\"Because of the Lord's great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.\"</p><span class=\"verse-ref\">Lamentations 3:22-23</span>",
-            "think": "<p>We do not begin the day empty-handed. Before we pray the first prayer or make the first decision, God has already provided mercy for this day. Yesterday's failures do not get the final word. Today begins under the faithfulness of God.</p><p>His mercies are not recycled leftovers. They are new every morning, fitted for today's needs, today's burdens, and today's opportunities. You can walk forward with confidence because His compassion has already gone before you.</p>",
-            "pray": "<p>Faithful God, thank You for new mercies this morning. I receive Your compassion for this day and release yesterday into Your hands. Help me walk in fresh grace and renewed trust. Amen.</p>",
-            "go_action": "<p>Begin today by thanking God for three fresh mercies you can already see.</p>",
-            "verses": "[\"Lamentations:3:22-23\",\"Psalm:5:3\",\"Isaiah:33:2\"]"
-        },
-        {
-            "day_number": 122,
-            "title": "Ask for Wisdom",
-            "pause": "<p>Bring your unanswered questions to God. He does not shame those who ask for help.</p>",
-            "listen": "<p>\"If any of you lacks wisdom, you should ask God, who gives generously to all without finding fault, and it will be given to you.\"</p><span class=\"verse-ref\">James 1:5</span>",
-            "think": "<p>Many of us ask God for strength, provision, or direction, yet forget to ask for wisdom. But wisdom is one of the clearest promises in Scripture. God gives it generously, not reluctantly. He is not irritated by your need for guidance; He welcomes it.</p><p>Wisdom helps you respond rather than react, discern rather than drift, and obey rather than guess. When you are unsure what to do next, begin by asking the God who delights to guide His children.</p>",
-            "pray": "<p>Lord, I need Your wisdom today. Show me how to think, speak, and act in ways that honor You. Guard me from leaning on my own understanding, and teach me to walk in Your counsel. Amen.</p>",
-            "go_action": "<p>Write down one decision you need wisdom for and pray over it before doing anything else.</p>",
-            "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
-        },
-        {
-            "day_number": 123,
-            "title": "Abide, Do Not Strive",
-            "pause": "<p>Take a slow breath. God is not asking you to manufacture fruit in your own strength.</p>",
-            "listen": "<p>\"Remain in me, as I also remain in you. No branch can bear fruit by itself; it must remain in the vine.\"</p><span class=\"verse-ref\">John 15:4</span>",
-            "think": "<p>We often treat spiritual growth like a personal project to manage. Yet Jesus gives a different invitation: remain. Fruit grows from connection, not anxiety. A branch does not become fruitful by clenching harder, but by staying joined to the vine.</p><p>If you feel spiritually dry, the answer is not more striving. It is deeper abiding. Stay close through prayer, Scripture, obedience, and quiet trust. The life of Christ in you will accomplish what pressure never can.</p>",
-            "pray": "<p>Jesus, keep me close to You. Forgive me for striving in places where You are calling me to abide. Root me in Your presence so that real fruit grows from my life. Amen.</p>",
-            "go_action": "<p>Set aside ten quiet minutes today simply to sit with God without rushing to perform.</p>",
-            "verses": "[\"John:15:4\",\"Psalm:1:2-3\",\"Galatians:5:22-23\"]"
-        },
-        {
-            "day_number": 124,
-            "title": "Peace for the Mind",
-            "pause": "<p>Lay your racing thoughts before the Lord. He cares about the inner noise you carry.</p>",
-            "listen": "<p>\"You will keep in perfect peace those whose minds are steadfast, because they trust in you.\"</p><span class=\"verse-ref\">Isaiah 26:3</span>",
-            "think": "<p>Peace is not produced by controlling every outcome. It is the fruit of fixing your mind on the One who does not change. When your thoughts scatter, your soul often follows. But when you return your mind to God, peace begins to steady your heart.</p><p>Perfect peace does not mean a trouble-free life. It means a held life. God can keep what you entrust to Him, including your thoughts, fears, and unanswered concerns.</p>",
-            "pray": "<p>God of peace, steady my mind today. Draw my thoughts back to Your truth whenever anxiety rises. I choose to trust You more than I trust my own worries. Amen.</p>",
-            "go_action": "<p>When anxious thoughts come today, pause and repeat: \"You will keep in perfect peace...\"</p>",
-            "verses": "[\"Isaiah:26:3\",\"Philippians:4:6-7\",\"2 Corinthians:10:5\"]"
-        },
-        {
-            "day_number": 125,
-            "title": "Faithful in Small Things",
-            "pause": "<p>Do not overlook the ordinary assignments in front of you. God sees hidden faithfulness.</p>",
-            "listen": "<p>\"Whoever can be trusted with very little can also be trusted with much...\"</p><span class=\"verse-ref\">Luke 16:10</span>",
-            "think": "<p>We often want visible impact while neglecting quiet obedience. But God builds lives of weight through small acts of faithfulness repeated over time. Integrity in private, kindness in routine moments, and diligence in simple tasks matter deeply to Him.</p><p>The small thing in your hand today may be the training ground for tomorrow's assignment. Do not despise the ordinary. God often measures greatness by faithfulness, not by attention.</p>",
-            "pray": "<p>Lord, make me faithful in the small things. Help me serve with integrity when no one is watching and obey with joy even in ordinary moments. Shape my character through daily faithfulness. Amen.</p>",
-            "go_action": "<p>Choose one small responsibility today and do it wholeheartedly as an act of worship.</p>",
-            "verses": "[\"Luke:16:10\",\"Colossians:3:23\",\"Zechariah:4:10\"]"
-        },
-        {
-            "day_number": 126,
-            "title": "God Gives Rest",
-            "pause": "<p>Let your soul unclench. You are allowed to rest in the care of God.</p>",
-            "listen": "<p>\"Come to me, all you who are weary and burdened, and I will give you rest.\"</p><span class=\"verse-ref\">Matthew 11:28</span>",
-            "think": "<p>Jesus does not merely command weary people to keep going; He invites them to come. Rest is not weakness. It is trust. It is the refusal to live as though everything depends on your effort.</p><p>There is a rest deeper than sleep: the rest of handing your burden to Christ. You may still have responsibilities, but you do not have to carry them alone. The gentle Savior knows how to hold what exhausts you.</p>",
-            "pray": "<p>Jesus, I come to You with the weight I have been carrying. Give rest to my soul and teach me the unforced rhythm of grace. Help me receive Your peace today. Amen.</p>",
-            "go_action": "<p>Make one practical choice today that honors rest rather than hurry.</p>",
-            "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Hebrews:4:9-10\"]"
-        },
-        {
-            "day_number": 127,
-            "title": "Quick to Listen",
-            "pause": "<p>Slow your words and quiet your reactions. Invite God to shape how you listen.</p>",
-            "listen": "<p>\"Everyone should be quick to listen, slow to speak and slow to become angry.\"</p><span class=\"verse-ref\">James 1:19</span>",
-            "think": "<p>Many conflicts are not caused by lack of words, but by lack of listening. Scripture calls us into a holy slowness: quick to listen, slow to speak, slow to anger. This is more than good advice; it is Spirit-formed wisdom.</p><p>Listening is an act of humility. It makes room for understanding, softens impulsive reactions, and reflects the patience of Christ. When you listen well, you love well.</p>",
-            "pray": "<p>Father, teach me to listen before I react. Guard my mouth, soften my tone, and slow my anger. Let my words today be marked by grace and wisdom. Amen.</p>",
-            "go_action": "<p>In your next conversation, focus on understanding first instead of preparing your reply.</p>",
-            "verses": "[\"James:1:19\",\"Proverbs:15:1\",\"Ephesians:4:29\"]"
-        },
-        {
-            "day_number": 128,
-            "title": "Strength for Today",
-            "pause": "<p>You do not need tomorrow's strength today. God supplies what this day requires.</p>",
-            "listen": "<p>\"My grace is sufficient for you, for my power is made perfect in weakness.\"</p><span class=\"verse-ref\">2 Corinthians 12:9</span>",
-            "think": "<p>Weakness often feels like failure, yet Paul learned that it can become the very place where the power of Christ rests most clearly. God's grace is not theoretical support. It is active strength for present need.</p><p>You may feel inadequate for what is in front of you, but God has never depended on your adequacy. He delights to display His sufficiency in surrendered weakness. Bring Him your limits and watch what grace can do.</p>",
-            "pray": "<p>Lord, I confess my weakness to You without shame. Let Your power be made perfect in me today. I receive the grace that is sufficient for this moment. Amen.</p>",
-            "go_action": "<p>Name one area where you feel weak and specifically invite God's strength into it.</p>",
-            "verses": "[\"2 Corinthians:12:9\",\"Isaiah:40:29-31\",\"Philippians:4:13\"]"
-        },
-        {
-            "day_number": 129,
-            "title": "Guard Your Heart",
-            "pause": "<p>Pause long enough to notice what has been shaping your inner life lately.</p>",
-            "listen": "<p>\"Above all else, guard your heart, for everything you do flows from it.\"</p><span class=\"verse-ref\">Proverbs 4:23</span>",
-            "think": "<p>Your heart is not a minor detail in your life with God. It is the wellspring from which your words, desires, choices, and habits flow. What you repeatedly allow into your heart will eventually appear in your life.</p><p>Guarding your heart is not fearful isolation; it is wise stewardship. Pay attention to what nourishes your soul and what drains it. Let truth, worship, and godly influences shape what lives within you.</p>",
-            "pray": "<p>God, help me guard my heart with wisdom. Expose whatever is shaping me away from You, and plant in me what is pure, steady, and life-giving. Amen.</p>",
-            "go_action": "<p>Remove one unhealthy influence from your day and replace it with Scripture or worship.</p>",
-            "verses": "[\"Proverbs:4:23\",\"Philippians:4:8\",\"Psalm:119:11\"]"
-        },
-        {
-            "day_number": 130,
-            "title": "The Lord Is Near",
-            "pause": "<p>Whatever feels distant or unclear, let this truth come close: the Lord is near.</p>",
-            "listen": "<p>\"The Lord is near to all who call on him, to all who call on him in truth.\"</p><span class=\"verse-ref\">Psalm 145:18</span>",
-            "think": "<p>God is not difficult to reach. He is near to those who call on Him in truth, with sincerity and dependence. You do not need polished words or perfect emotions. Honest prayer is enough.</p><p>His nearness is one of the deepest comforts in the Christian life. In loneliness, confusion, temptation, or grief, you are not abandoned to your own strength. Call on Him, and trust that He is present.</p>",
-            "pray": "<p>Near God, thank You that You are close when I call. Teach me to come to You honestly and often. Let the awareness of Your presence steady my heart today. Amen.</p>",
-            "go_action": "<p>Take a few one-minute prayer pauses throughout the day to simply say, \"Lord, You are near.\"</p>",
-            "verses": "[\"Psalm:145:18\",\"Deuteronomy:4:7\",\"James:4:8\"]"
-        },
-        {
-            "day_number": 131,
-            "title": "Led by the Spirit",
-            "pause": "<p>Before you rush ahead, ask the Holy Spirit to lead your next step.</p>",
-            "listen": "<p>\"Since we live by the Spirit, let us keep in step with the Spirit.\"</p><span class=\"verse-ref\">Galatians 5:25</span>",
-            "think": "<p>The Christian life is more than avoiding wrong; it is walking in step with the Spirit. This means paying attention to His promptings, yielding our impulses, and learning a pace of obedience that stays close to Him.</p><p>The Spirit does not merely correct you after the fact. He leads you in the moment, giving restraint where needed and courage where required. Stay responsive. A yielded heart becomes a guided life.</p>",
-            "pray": "<p>Holy Spirit, help me keep in step with You today. Make me sensitive to Your guidance, quick to obey, and willing to slow down when You say wait. Lead me in the way of Christ. Amen.</p>",
-            "go_action": "<p>Before one key decision today, pause and ask the Spirit to lead you instead of reacting immediately.</p>",
-            "verses": "[\"Galatians:5:25\",\"Romans:8:14\",\"John:16:13\"]"
-        },
-        {
-            "day_number": 132,
-            "title": "Kindness Is Strength",
-            "pause": "<p>Consider the people you will meet today. Ask God to make your heart gentle.</p>",
-            "listen": "<p>\"Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you.\"</p><span class=\"verse-ref\">Ephesians 4:32</span>",
-            "think": "<p>Kindness is not weakness. It is strength governed by grace. In a harsh world, kindness reflects the character of Christ in practical and powerful ways. It softens tension, dignifies people, and reminds the heart of God.</p><p>Forgiven people are called to become forgiving people. The kindness you extend today may be the very thing that opens a weary heart to hope.</p>",
-            "pray": "<p>Lord, make me kind in word, patient in tone, and compassionate in spirit. Help me reflect the mercy You have shown me, especially when it costs me something. Amen.</p>",
-            "go_action": "<p>Offer one intentional act of kindness today with no desire for recognition.</p>",
-            "verses": "[\"Ephesians:4:32\",\"Colossians:3:12\",\"Proverbs:21:21\"]"
-        },
-        {
-            "day_number": 133,
-            "title": "Do Not Grow Weary",
-            "pause": "<p>If your heart feels tired from doing good, bring that weariness to God.</p>",
-            "listen": "<p>\"Let us not become weary in doing good, for at the proper time we will reap a harvest if we do not give up.\"</p><span class=\"verse-ref\">Galatians 6:9</span>",
-            "think": "<p>Weariness often comes when faithfulness seems unnoticed or fruit seems delayed. Yet Scripture reminds us that there is a proper time for harvest. God sees the seeds you keep planting, the prayers you keep praying, and the obedience you keep choosing.</p><p>Do not let discouragement convince you that perseverance is pointless. The field may look quiet, but God is still at work beneath the surface. Keep going.</p>",
-            "pray": "<p>Father, strengthen me where I have grown tired. Renew my courage to keep doing good without losing heart. Help me trust that You will bring fruit in Your time. Amen.</p>",
-            "go_action": "<p>Recommit today to one good and godly thing you have been tempted to stop doing.</p>",
-            "verses": "[\"Galatians:6:9\",\"1 Corinthians:15:58\",\"Hebrews:10:36\"]"
-        },
-        {
-            "day_number": 134,
-            "title": "A Lamp for Your Feet",
-            "pause": "<p>You do not need the whole roadmap right now. Let God light the next step.</p>",
-            "listen": "<p>\"Your word is a lamp for my feet, a light on my path.\"</p><span class=\"verse-ref\">Psalm 119:105</span>",
-            "think": "<p>God's Word often works like a lamp, not a floodlight. It gives enough light for the step in front of you, not always the full picture. This requires trust. We want clarity for the whole journey, but God often offers guidance one obedient step at a time.</p><p>When Scripture shapes your path, confusion begins to lose its control. Keep returning to the Word. It will steady your feet and form your discernment.</p>",
-            "pray": "<p>Lord, let Your Word guide me today. Illuminate the next right step and keep me from wandering in my own understanding. Give me a heart that listens and obeys. Amen.</p>",
-            "go_action": "<p>Read one short passage of Scripture slowly today and ask, \"What is my next step of obedience?\"</p>",
-            "verses": "[\"Psalm:119:105\",\"Joshua:1:8\",\"2 Timothy:3:16-17\"]"
-        },
-        {
-            "day_number": 135,
-            "title": "Prayer Changes the Atmosphere",
-            "pause": "<p>Before you face the situation, invite God into it through prayer.</p>",
-            "listen": "<p>\"The prayer of a righteous person is powerful and effective.\"</p><span class=\"verse-ref\">James 5:16</span>",
-            "think": "<p>Prayer is not a last resort for helpless people; it is a first response for dependent people. It does not merely comfort the heart. It invites the rule and help of God into real situations. Prayer changes us, but it also changes what happens around us.</p><p>Do not underestimate a quiet prayer whispered in faith. Heaven hears. God works. What seems small in the moment can become powerful in His hands.</p>",
-            "pray": "<p>Lord, teach me to turn to prayer quickly and confidently. Strengthen my faith to believe that You hear and act. Let prayer become a steady rhythm in my life. Amen.</p>",
-            "go_action": "<p>Pray immediately about one issue you have only been worrying about.</p>",
-            "verses": "[\"James:5:16\",\"Philippians:4:6\",\"1 Thessalonians:5:17\"]"
-        },
-        {
-            "day_number": 136,
-            "title": "Content in Christ",
-            "pause": "<p>Release the pressure to have more, be more, or prove more. Christ is enough.</p>",
-            "listen": "<p>\"I have learned the secret of being content in any and every situation...\"</p><span class=\"verse-ref\">Philippians 4:12</span>",
-            "think": "<p>Contentment is not found in ideal circumstances, but in a stable center. Paul learned contentment not because life was easy, but because Christ was sufficient. The heart that is anchored in Jesus is less controlled by comparison, envy, or fear.</p><p>Contentment does not mean passivity. It means receiving today as a place where God is present and enough. From that place, gratitude grows.</p>",
-            "pray": "<p>Jesus, teach me the secret of contentment. Free me from comparison and restless striving. Help me find my security and joy in You above all else. Amen.</p>",
-            "go_action": "<p>List five gifts from God in your present season and thank Him for each one.</p>",
-            "verses": "[\"Philippians:4:11-13\",\"Hebrews:13:5\",\"Psalm:16:5-6\"]"
-        },
-        {
-            "day_number": 137,
-            "title": "God Hears the Brokenhearted",
-            "pause": "<p>If your heart is heavy, do not rush past that pain. Bring it honestly before God.</p>",
-            "listen": "<p>\"The Lord is close to the brokenhearted and saves those who are crushed in spirit.\"</p><span class=\"verse-ref\">Psalm 34:18</span>",
-            "think": "<p>God does not move away from the brokenhearted. He moves close. Where others may not understand your grief, the Lord meets you with tender nearness. He is not impatient with pain. He is compassionate in it.</p><p>You do not have to clean up your sorrow before you come to Him. Bring your crushed spirit as it is. He knows how to hold what hurts.</p>",
-            "pray": "<p>Lord, draw near to me in every place of pain. Hold my heart, steady my thoughts, and remind me that I am not alone. Thank You for being close when I feel weak. Amen.</p>",
-            "go_action": "<p>Give God honest words for your grief today instead of hiding it behind strength.</p>",
-            "verses": "[\"Psalm:34:18\",\"Matthew:5:4\",\"2 Corinthians:1:3-4\"]"
-        },
-        {
-            "day_number": 138,
-            "title": "Serve with Joy",
-            "pause": "<p>Offer today to God again. Ask Him to make even simple service full of love.</p>",
-            "listen": "<p>\"Serve the Lord with gladness; come before him with joyful songs.\"</p><span class=\"verse-ref\">Psalm 100:2</span>",
-            "think": "<p>Service can become draining when it is driven by obligation or approval-seeking. But when it is offered to the Lord, it becomes worship. Joy grows when we remember who we are serving and why it matters.</p><p>You may not always feel excited about every task, but God can renew the spirit in which you serve. Gladness is often found not before obedience, but within it.</p>",
-            "pray": "<p>Father, renew the joy of serving You. Purify my motives and help me carry out today's work with gladness and love. Let my service point to Your goodness. Amen.</p>",
-            "go_action": "<p>Choose one act of service today and do it cheerfully as worship to God.</p>",
-            "verses": "[\"Psalm:100:2\",\"Colossians:3:23-24\",\"Mark:10:45\"]"
-        },
-        {
-            "day_number": 139,
-            "title": "Trust the Slow Work of God",
-            "pause": "<p>If growth feels slow, do not assume God is absent. He often works deeply before He works visibly.</p>",
-            "listen": "<p>\"Being confident of this, that he who began a good work in you will carry it on to completion...\"</p><span class=\"verse-ref\">Philippians 1:6</span>",
-            "think": "<p>Transformation usually happens gradually. We want immediate maturity, quick answers, and visible progress. But God often forms us through slow faithfulness, hidden roots, and patient surrender. His pace is wise.</p><p>Do not confuse unfinished with abandoned. If God began the work, He will continue it. Your growth may be quieter than you hoped, but it is not absent from His hands.</p>",
-            "pray": "<p>Lord, help me trust Your timing in my growth. Keep me from discouragement when progress feels slow, and remind me that You always finish what You begin. Amen.</p>",
-            "go_action": "<p>Notice one area where God has grown you over time, even if slowly, and thank Him for it.</p>",
-            "verses": "[\"Philippians:1:6\",\"Ecclesiastes:3:11\",\"Hebrews:12:1-2\"]"
-        },
-        {
-            "day_number": 140,
-            "title": "Courage to Obey",
-            "pause": "<p>Bring to mind the thing God has made clear but you have hesitated to do.</p>",
-            "listen": "<p>\"Be strong and courageous. Do not be afraid; do not be discouraged, for the Lord your God will be with you wherever you go.\"</p><span class=\"verse-ref\">Joshua 1:9</span>",
-            "think": "<p>Courage in Scripture is rarely the absence of fear. It is the choice to obey while trusting the presence of God. Joshua needed courage not because God was absent, but because God was with him and calling him forward.</p><p>When obedience feels costly, remember what makes courage possible: the Lord your God will be with you. His presence is greater than your fear.</p>",
-            "pray": "<p>God, give me courage to obey You fully. Where I have delayed through fear, strengthen me to move forward in faith. Thank You that You go with me. Amen.</p>",
-            "go_action": "<p>Take one concrete step today toward something God has already shown you to do.</p>",
-            "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
-        },
-        {
-            "day_number": 141,
-            "title": "Words That Give Life",
-            "pause": "<p>Before you speak today, ask God to make your words healing rather than harmful.</p>",
-            "listen": "<p>\"The tongue has the power of life and death...\"</p><span class=\"verse-ref\">Proverbs 18:21</span>",
-            "think": "<p>Words carry weight. They can wound deeply, but they can also strengthen, encourage, and restore. God calls us to speak in ways that impart grace to those who hear.</p><p>Your speech today can reflect the heart of Christ. A timely encouragement, a gentle correction, a sincere apology, or a hopeful reminder can become life-giving in God's hands.</p>",
-            "pray": "<p>Lord, place a guard over my mouth. Let my words today be truthful, gracious, and life-giving. Use my speech to build up rather than tear down. Amen.</p>",
-            "go_action": "<p>Speak one deliberate word of encouragement to someone who needs it today.</p>",
-            "verses": "[\"Proverbs:18:21\",\"Ephesians:4:29\",\"Colossians:4:6\"]"
-        },
-        {
-            "day_number": 142,
-            "title": "God Is Your Refuge",
-            "pause": "<p>When pressure rises, do not run first to panic. Run to your refuge.</p>",
-            "listen": "<p>\"God is our refuge and strength, an ever-present help in trouble.\"</p><span class=\"verse-ref\">Psalm 46:1</span>",
-            "think": "<p>A refuge is not imaginary comfort; it is real shelter in real trouble. Scripture does not deny that storms come. It declares that God is a present help within them. He is not late, distant, or unsure of how to help.</p><p>When life feels unstable, remember where you can run. The heart anchored in God has a place to stand even when the ground shakes.</p>",
-            "pray": "<p>Refuge and strength, I run to You today. Be my steady place in trouble and my calm in uncertainty. Help me trust Your presence more than I fear my circumstances. Amen.</p>",
-            "go_action": "<p>When stress spikes today, stop and pray Psalm 46:1 before doing anything else.</p>",
-            "verses": "[\"Psalm:46:1\",\"Nahum:1:7\",\"Proverbs:18:10\"]"
-        },
-        {
-            "day_number": 143,
-            "title": "Live with Integrity",
-            "pause": "<p>Invite God to search the hidden places of your life, not just the visible ones.</p>",
-            "listen": "<p>\"The integrity of the upright guides them...\"</p><span class=\"verse-ref\">Proverbs 11:3</span>",
-            "think": "<p>Integrity is wholeness. It is the alignment of inner life and outward life, private devotion and public conduct. A life of integrity may not always be the easiest path, but it is a clear one.</p><p>God honors truth in the inward being. When you walk in integrity, you are less divided inside and more available to the peace of obedience.</p>",
-            "pray": "<p>Lord, make me a person of integrity. Keep me honest in motive, faithful in action, and transparent before You. Guide me by truth in all I do. Amen.</p>",
-            "go_action": "<p>Make one honest correction today in an area where you have been tempted to cut corners.</p>",
-            "verses": "[\"Proverbs:11:3\",\"Psalm:15:1-2\",\"Titus:2:7\"]"
-        },
-        {
-            "day_number": 144,
-            "title": "The Joy of the Lord",
-            "pause": "<p>Joy is not something you have to force. It begins in the presence of God.</p>",
-            "listen": "<p>\"Do not grieve, for the joy of the Lord is your strength.\"</p><span class=\"verse-ref\">Nehemiah 8:10</span>",
-            "think": "<p>The joy of the Lord is deeper than mood and stronger than circumstances. It is a stabilizing gladness rooted in who God is. This joy strengthens weary hearts because it reminds us that God remains good, present, and worthy of trust.</p><p>You may not feel cheerful today, but you can still draw strength from the joy found in God's presence. Let His joy become your strength.</p>",
-            "pray": "<p>Father, renew holy joy in me. Lift the heaviness that has weighed down my spirit and let Your joy strengthen me from within. Amen.</p>",
-            "go_action": "<p>Spend a few minutes thanking God out loud for who He is, not just what He gives.</p>",
-            "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
-        },
-        {
-            "day_number": 145,
-            "title": "Wait with Hope",
-            "pause": "<p>Waiting can feel empty, but with God it is often full of hidden work.</p>",
-            "listen": "<p>\"I remain confident of this: I will see the goodness of the Lord in the land of the living. Wait for the Lord; be strong and take heart and wait for the Lord.\"</p><span class=\"verse-ref\">Psalm 27:13-14</span>",
-            "think": "<p>Waiting is one of the hardest forms of faith because it requires trust without visible control. Yet biblical waiting is not passive despair. It is strong-hearted confidence that God will show His goodness in His time.</p><p>What you do while you wait matters. Waiting can deepen dependence, refine desire, and train the heart in hope. Do not waste the waiting season by assuming nothing is happening.</p>",
-            "pray": "<p>Lord, strengthen my heart while I wait. Keep me from despair, impatience, or unbelief. Help me remain confident in Your goodness. Amen.</p>",
-            "go_action": "<p>Identify one area of waiting in your life and pray over it with hope instead of frustration.</p>",
-            "verses": "[\"Psalm:27:13-14\",\"Isaiah:40:31\",\"Romans:8:25\"]"
-        },
-        {
-            "day_number": 146,
-            "title": "Freely Receive, Freely Give",
-            "pause": "<p>Remember how generously God has dealt with you.</p>",
-            "listen": "<p>\"Freely you have received; freely give.\"</p><span class=\"verse-ref\">Matthew 10:8</span>",
-            "think": "<p>Grace was never meant to stop with us. What we have received from God, we are invited to extend to others: mercy, generosity, patience, truth, and care. The gospel produces open-handed people.</p><p>When you remember how much you have received, giving becomes less about loss and more about participation in the heart of God. Grace flows best through grateful hands.</p>",
-            "pray": "<p>Generous God, thank You for all I have freely received in Christ. Help me live open-handedly today, ready to give love, time, encouragement, and help where needed. Amen.</p>",
-            "go_action": "<p>Give something today without expecting anything in return.</p>",
-            "verses": "[\"Matthew:10:8\",\"2 Corinthians:9:8\",\"Acts:20:35\"]"
-        },
-        {
-            "day_number": 147,
-            "title": "His Grace Teaches You",
-            "pause": "<p>Do not think of grace as permission to stay stuck. Grace trains and transforms.</p>",
-            "listen": "<p>\"For the grace of God has appeared... It teaches us to say 'No' to ungodliness and worldly passions...\"</p><span class=\"verse-ref\">Titus 2:11-12</span>",
-            "think": "<p>Grace not only forgives; it forms. It teaches us how to live differently, turning our hearts away from what destroys and toward what reflects Christ. This means your growth is not sustained by guilt, but by grace.</p><p>Where you need change, do not begin with self-condemnation. Begin with the grace of God, which is powerful enough to both pardon and transform.</p>",
-            "pray": "<p>Lord, let Your grace teach me today. Shape my desires, strengthen my obedience, and help me say no to what pulls me away from You. Amen.</p>",
-            "go_action": "<p>Ask God to show you one pattern He wants to reshape by grace, and respond with obedience.</p>",
-            "verses": "[\"Titus:2:11-12\",\"Romans:6:14\",\"Ezekiel:36:26-27\"]"
-        },
-        {
-            "day_number": 148,
-            "title": "Blessed Are the Peacemakers",
-            "pause": "<p>Bring to mind a relationship or setting that needs peace.</p>",
-            "listen": "<p>\"Blessed are the peacemakers, for they will be called children of God.\"</p><span class=\"verse-ref\">Matthew 5:9</span>",
-            "think": "<p>Peacemaking is not avoiding tension at all costs. It is the courageous work of pursuing truth, humility, and reconciliation in ways that reflect the heart of God. Peace often requires wisdom, patience, and initiative.</p><p>As children of God, we are called not only to enjoy peace but also to carry it. Ask God how you might become an agent of peace where there has been friction or distance.</p>",
-            "pray": "<p>Father, make me a peacemaker. Give me wisdom, humility, and courage in strained relationships. Let my life reflect the reconciling heart of Christ. Amen.</p>",
-            "go_action": "<p>Take one humble step toward peace today, whether through apology, forgiveness, or a gracious conversation.</p>",
-            "verses": "[\"Matthew:5:9\",\"Romans:12:18\",\"Colossians:3:15\"]"
-        },
-        {
-            "day_number": 149,
-            "title": "Sing in the Night",
-            "pause": "<p>Even if this season feels dark, God remains worthy of worship.</p>",
-            "listen": "<p>\"About midnight Paul and Silas were praying and singing hymns to God...\"</p><span class=\"verse-ref\">Acts 16:25</span>",
-            "think": "<p>Paul and Silas did not wait for favorable conditions before worshiping. In pain and uncertainty, they prayed and sang. Their praise was not denial; it was defiant trust in the goodness and sovereignty of God.</p><p>Worship in dark places has a way of lifting your eyes above the prison walls. It does not always change the situation immediately, but it changes the atmosphere of the heart.</p>",
-            "pray": "<p>Lord, teach me to worship You even in hard places. Let prayer and praise rise from my heart when circumstances are heavy. You are worthy in every season. Amen.</p>",
-            "go_action": "<p>Play a worship song today in a moment you would normally spend worrying.</p>",
-            "verses": "[\"Acts:16:25\",\"Habakkuk:3:17-18\",\"Psalm:42:8\"]"
-        },
-        {
-            "day_number": 150,
-            "title": "Love Is the Better Way",
-            "pause": "<p>Let your heart settle on what matters most before God.</p>",
-            "listen": "<p>\"And now these three remain: faith, hope and love. But the greatest of these is love.\"</p><span class=\"verse-ref\">1 Corinthians 13:13</span>",
-            "think": "<p>Love is not sentimental weakness. It is the mature expression of a life shaped by God. Gifts matter. Knowledge matters. Discipline matters. But without love, even impressive things lose their true weight.</p><p>Ask yourself not only whether what you do is right, but whether it is rooted in love. Love is the better way because it reflects the very nature of God.</p>",
-            "pray": "<p>God of love, reorder my heart today. Let love shape my motives, guide my words, and mark my actions. Teach me to live in the better way. Amen.</p>",
-            "go_action": "<p>Choose one difficult person or situation today and intentionally respond in love.</p>",
-            "verses": "[\"1 Corinthians:13:13\",\"John:13:34-35\",\"1 John:4:7-8\"]"
-        },
-        {
-            "day_number": 151,
-            "title": "Held by Everlasting Arms",
-            "pause": "<p>At the close of this stretch of devotionals, rest in the truth that you are being held.</p>",
-            "listen": "<p>\"The eternal God is your refuge, and underneath are the everlasting arms.\"</p><span class=\"verse-ref\">Deuteronomy 33:27</span>",
-            "think": "<p>There are seasons when you feel strong, and there are seasons when you simply need to be carried. Scripture reminds us that underneath every trembling step of faith are the everlasting arms of God. You are upheld by strength older and steadier than your fears.</p><p>What holds you is not your grip on God, but His grip on you. That is why you can rest. His arms do not tire, and His care does not fail.</p>",
-            "pray": "<p>Eternal God, thank You for being my refuge and strength. When I feel weak, remind me that Your everlasting arms are underneath me. Teach me to rest in Your keeping love. Amen.</p>",
-            "go_action": "<p>End the day by placing your worries one by one into the care of God and thanking Him for holding you.</p>",
-            "verses": "[\"Deuteronomy:33:27\",\"Isaiah:46:4\",\"John:10:28-29\"]"
-        }
-    ]
+  "version": 5,
+  "devotionals": [
+    {
+      "day_number": 1,
+      "title": "Hope for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 2,
+      "title": "Peace in the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 3,
+      "title": "Strength for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 4,
+      "title": "Wisdom for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 5,
+      "title": "Grace in the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 6,
+      "title": "Joy for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 7,
+      "title": "Trust in the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 8,
+      "title": "Rest for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 9,
+      "title": "Courage for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 10,
+      "title": "Mercy for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 11,
+      "title": "Light for the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 12,
+      "title": "Love in the Early Morning",
+      "pause": "<p>Pause for a moment. Bring the opening of this day before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Beginnings are often full of quiet need. God meets you before the day unfolds and before you have proved anything.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the beginning of this day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Start the morning with one minute of quiet gratitude as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 13,
+      "title": "Hope for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 14,
+      "title": "Peace in the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 15,
+      "title": "Strength for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 16,
+      "title": "Wisdom for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 17,
+      "title": "Grace in the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 18,
+      "title": "Joy for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 19,
+      "title": "Trust in the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 20,
+      "title": "Rest for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 21,
+      "title": "Courage for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 22,
+      "title": "Mercy for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 23,
+      "title": "Light for the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 24,
+      "title": "Love in the Next Step",
+      "pause": "<p>Pause for a moment. Bring the next decision in front of you before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>God usually leads His people faithfully one step at a time. Clarity often grows through obedience, not before it.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the step in front of me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take one simple step of obedience you already know is right as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 25,
+      "title": "Hope for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 26,
+      "title": "Peace in Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 27,
+      "title": "Strength for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 28,
+      "title": "Wisdom for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 29,
+      "title": "Grace in Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 30,
+      "title": "Joy for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 31,
+      "title": "Trust in Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 32,
+      "title": "Rest for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 33,
+      "title": "Courage for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 34,
+      "title": "Mercy for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 35,
+      "title": "Light for Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 36,
+      "title": "Love in Anxious Thoughts",
+      "pause": "<p>Pause for a moment. Bring the thoughts that keep circling in your mind before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Anxiety grows louder when the heart carries alone what was meant to be entrusted to God.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my restless thoughts. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Turn one anxious thought into a spoken prayer as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 37,
+      "title": "Hope for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 38,
+      "title": "Peace in the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 39,
+      "title": "Strength for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 40,
+      "title": "Wisdom for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 41,
+      "title": "Grace in the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 42,
+      "title": "Joy for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 43,
+      "title": "Trust in the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 44,
+      "title": "Rest for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 45,
+      "title": "Courage for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 46,
+      "title": "Mercy for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 47,
+      "title": "Light for the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 48,
+      "title": "Love in the Waiting Season",
+      "pause": "<p>Pause for a moment. Bring the things you are still waiting to see resolved before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Waiting can feel hidden, but God is still active there. He uses delay to deepen trust, patience, and hope.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in this waiting season. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Name one thing you are waiting for and surrender it again to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 49,
+      "title": "Hope for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 50,
+      "title": "Peace in Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 51,
+      "title": "Strength for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 52,
+      "title": "Wisdom for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 53,
+      "title": "Grace in Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 54,
+      "title": "Joy for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 55,
+      "title": "Trust in Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 56,
+      "title": "Rest for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 57,
+      "title": "Courage for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 58,
+      "title": "Mercy for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 59,
+      "title": "Light for Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 60,
+      "title": "Love in Daily Work",
+      "pause": "<p>Pause for a moment. Bring the work set before you today before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Ordinary work matters to God when it is offered to Him. Faithfulness in daily tasks is a form of worship.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the work of my hands. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Begin one task by offering it to God before you measure it as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 61,
+      "title": "Hope for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 62,
+      "title": "Peace in the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 63,
+      "title": "Strength for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 64,
+      "title": "Wisdom for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 65,
+      "title": "Grace in the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 66,
+      "title": "Joy for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 67,
+      "title": "Trust in the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 68,
+      "title": "Rest for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 69,
+      "title": "Courage for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 70,
+      "title": "Mercy for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 71,
+      "title": "Light for the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 72,
+      "title": "Love in the Quiet Battle",
+      "pause": "<p>Pause for a moment. Bring the inner battles others may not see before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Some of the most important spiritual battles happen in secret places of thought, desire, and hidden perseverance.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the unseen battles within me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Bring one hidden struggle into the light of prayer today as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 73,
+      "title": "Hope for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 74,
+      "title": "Peace in Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 75,
+      "title": "Strength for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 76,
+      "title": "Wisdom for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 77,
+      "title": "Grace in Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 78,
+      "title": "Joy for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 79,
+      "title": "Trust in Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 80,
+      "title": "Rest for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 81,
+      "title": "Courage for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 82,
+      "title": "Mercy for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 83,
+      "title": "Light for Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 84,
+      "title": "Love in Uncertain Paths",
+      "pause": "<p>Pause for a moment. Bring what feels unclear or unresolved before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Uncertainty does not mean God has stopped leading. It often becomes a place where dependence grows stronger.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the places that feel unclear. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God for direction before making one decision today as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 85,
+      "title": "Hope for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 86,
+      "title": "Peace in a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 87,
+      "title": "Strength for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 88,
+      "title": "Wisdom for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 89,
+      "title": "Grace in a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 90,
+      "title": "Joy for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 91,
+      "title": "A New Season of Hope",
+      "pause": "<p>Take a deep breath. Let the worries of yesterday fade. God is doing something new in your life today. Be still and know that He is God.</p>",
+      "listen": "<p>\"See, I am doing a new thing! Now it springs up; do you not perceive it? I am making a way in the wilderness and streams in the wasteland.\"</p><span class=\"verse-ref\">Isaiah 43:19</span>",
+      "think": "<p>April marks a season of renewal. Trees bud, flowers bloom, and creation itself declares that God specializes in making all things new. Whatever barren season you have walked through, God is faithful to bring forth life again.</p><p>The same God who commands spring to come after winter is working behind the scenes in your life. Trust His timing. The new thing He promised is already springing up.</p>",
+      "pray": "<p>Lord, open my eyes to see the new things You are doing in my life. Help me trust Your timing even when the season feels long. I choose to believe that You are making a way where there seems to be none. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Write down one area of your life where you need God to do something new. Place it somewhere visible and pray over it this week.</p>",
+      "verses": "[\"Isaiah:43:19\",\"Lamentations:3:22-23\",\"Revelation:21:5\"]"
+    },
+    {
+      "day_number": 92,
+      "title": "The Power of the Resurrection",
+      "pause": "<p>Close your eyes. Picture the empty tomb on that first Easter morning. The stone rolled away. Death defeated. Let that reality sink deep into your heart.</p>",
+      "listen": "<p>\"I want to know Christ â€” yes, to know the power of his resurrection and participation in his sufferings, becoming like him in his death, and so, somehow, attaining to the resurrection from the dead.\"</p><span class=\"verse-ref\">Philippians 3:10-11</span>",
+      "think": "<p>Paul did not merely want to know about the resurrection â€” he wanted to <em>experience</em> its power in his daily life. The same power that raised Jesus from the dead lives inside every believer. This is not a distant theological concept; it is a present reality.</p><p>When you face impossible situations, remember: you carry resurrection power within you. The God who conquered the grave is more than able to handle whatever you are walking through today.</p>",
+      "pray": "<p>Father, I want to know the power of Christ's resurrection in my everyday life. Strengthen me by Your Spirit. Let the same power that raised Jesus from the dead work mightily in me today. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Identify one area where you feel defeated or hopeless. Speak the truth of the resurrection over it: \"The same power that raised Christ from the dead is alive in me.\"</p>",
+      "verses": "[\"Philippians:3:10\",\"Ephesians:1:19-20\",\"Romans:8:11\"]"
+    },
+    {
+      "day_number": 93,
+      "title": "Walking in Newness of Life",
+      "pause": "<p>Be still for a moment. You are not who you used to be. In Christ, you are a new creation. Let that truth settle in your spirit.</p>",
+      "listen": "<p>\"Therefore, if anyone is in Christ, the new creation has come: The old has gone, the new is here!\"</p><span class=\"verse-ref\">2 Corinthians 5:17</span>",
+      "think": "<p>When you gave your life to Christ, something radical happened â€” your old identity died, and a brand-new you was born. You are not a cleaned-up version of your former self. You are an entirely new creation with a new nature, a new purpose, and a new destiny.</p><p>Stop looking in the rearview mirror at who you were. God is not holding your past against you. Walk boldly into the newness of life He has prepared for you.</p>",
+      "pray": "<p>Jesus, thank You for making me new. Help me to stop living as though my old identity still defines me. I receive my new identity in You. Teach me to walk in the fullness of the new creation I have become. Amen.</p>",
+      "go_action": "<p>Write down three things that are true about your new identity in Christ. Speak them aloud over yourself today.</p>",
+      "verses": "[\"2 Corinthians:5:17\",\"Romans:6:4\",\"Galatians:2:20\"]"
+    },
+    {
+      "day_number": 94,
+      "title": "He Carried Our Sorrows",
+      "pause": "<p>Sit quietly with God. If there is pain or grief in your heart, you do not need to hide it. He already knows, and He cares deeply.</p>",
+      "listen": "<p>\"Surely he took up our pain and bore our suffering, yet we considered him punished by God, stricken by him, and afflicted. But he was pierced for our transgressions, he was crushed for our iniquities; the punishment that brought us peace was on him, and by his wounds we are healed.\"</p><span class=\"verse-ref\">Isaiah 53:4-5</span>",
+      "think": "<p>Jesus did not merely observe our suffering from a distance. He entered into it fully. On the cross, He took upon Himself every sorrow, every sickness, every sin that weighs us down. He was crushed so that we could be made whole.</p><p>If you are carrying grief or pain today, know that Jesus has already carried it for you. You do not have to bear it alone. Lay your burdens at the foot of the cross and receive the peace that His sacrifice purchased for you.</p>",
+      "pray": "<p>Lord Jesus, thank You for carrying my pain and sorrows on the cross. I lay every burden at Your feet right now. I receive the healing and peace that Your wounds have purchased for me. Amen.</p>",
+      "go_action": "<p>Is there a sorrow you have been carrying alone? Tell God about it honestly in prayer, and then write down: \"Jesus has carried this for me.\"</p>",
+      "verses": "[\"Isaiah:53:4-5\",\"1 Peter:2:24\",\"Matthew:11:28\"]"
+    },
+    {
+      "day_number": 95,
+      "title": "The Lamb Who Was Slain",
+      "pause": "<p>Take a moment to reflect on the magnitude of God's love. Before the foundation of the world, He already had a plan to rescue you.</p>",
+      "listen": "<p>\"For you know that it was not with perishable things such as silver or gold that you were redeemed from the empty way of life handed down to you from your ancestors, but with the precious blood of Christ, a lamb without blemish or defect.\"</p><span class=\"verse-ref\">1 Peter 1:18-19</span>",
+      "think": "<p>Your redemption was not cheap. It cost the precious blood of the spotless Lamb of God. No amount of silver or gold could buy your freedom â€” only the sinless life of Jesus was sufficient to pay the price for your salvation.</p><p>When you begin to doubt your worth, remember the price that was paid for you. God did not spare His own Son because He considered you worth the sacrifice. You are that valuable to Him.</p>",
+      "pray": "<p>Father, I stand in awe of the price You paid for my redemption. Thank You for not sparing Your own Son but giving Him freely for me. Help me to live in a way that honors the precious blood of Jesus. Amen.</p>",
+      "go_action": "<p>Spend five minutes meditating on the cost of your salvation. Let gratitude fill your heart and shape how you treat others today.</p>",
+      "verses": "[\"1 Peter:1:18-19\",\"Revelation:5:12\",\"John:1:29\"]"
+    },
+    {
+      "day_number": 96,
+      "title": "From Darkness to Marvelous Light",
+      "pause": "<p>Close your eyes. Remember where you were before Christ found you. Now open them. Thank God for the light He has brought into your life.</p>",
+      "listen": "<p>\"But you are a chosen people, a royal priesthood, a holy nation, God's special possession, that you may declare the praises of him who called you out of darkness into his wonderful light.\"</p><span class=\"verse-ref\">1 Peter 2:9</span>",
+      "think": "<p>You were not pulled from darkness by accident. God <em>chose</em> you. He called you by name and brought you out of the shadows into His marvelous light. You are not a bystander in God's story â€” you are His special possession, set apart for a holy purpose.</p><p>Your identity is not based on your performance. You are chosen, royal, holy, and treasured. Let that truth define how you see yourself and how you walk through this day.</p>",
+      "pray": "<p>God, thank You for choosing me and calling me out of darkness. I receive my identity as Your special possession. Help me to walk as a child of light today and declare Your praises in everything I do. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Share your testimony with someone today â€” even a brief word about how God brought light into your darkness.</p>",
+      "verses": "[\"1 Peter:2:9\",\"Ephesians:5:8\",\"Colossians:1:13\"]"
+    },
+    {
+      "day_number": 97,
+      "title": "The Stone That Was Rolled Away",
+      "pause": "<p>Breathe deeply. Think of a situation in your life that feels sealed shut, like a stone blocking the way. Invite God into that space.</p>",
+      "listen": "<p>\"When they looked up, they saw that the stone, which was very large, had been rolled away.\"</p><span class=\"verse-ref\">Mark 16:4</span>",
+      "think": "<p>The women who went to the tomb that Sunday morning were worried about who would roll away the stone. It was massive, immovable by human strength. But when they arrived, the work was already done. God had moved the stone before they even got there.</p><p>Are you worried about obstacles that seem too big to move? God is already working ahead of you. The stone you are stressing about may already be rolled away by the time you arrive. Trust Him.</p>",
+      "pray": "<p>Lord, I bring You the stones in my life â€” the obstacles that feel immovable. I trust that You are already working ahead of me. Give me faith to keep walking forward, knowing that You will make a way. Amen.</p>",
+      "go_action": "<p>Name your \"stone\" â€” the biggest obstacle you face right now. Release it to God and take one step of faith toward it today.</p>",
+      "verses": "[\"Mark:16:4\",\"Matthew:28:2\",\"Luke:1:37\"]"
+    },
+    {
+      "day_number": 98,
+      "title": "Do Not Be Afraid",
+      "pause": "<p>Let your shoulders relax. Release the tension in your body. Hear the angel's words echo across the centuries: \"Do not be afraid.\"</p>",
+      "listen": "<p>\"The angel said to the women, 'Do not be afraid, for I know that you are looking for Jesus, who was crucified. He is not here; he has risen, just as he said.'\"</p><span class=\"verse-ref\">Matthew 28:5-6</span>",
+      "think": "<p>Fear is a natural human response to uncertainty. The women at the tomb were terrified. But the angel's first words were not a rebuke â€” they were comfort. God meets us in our fear with reassurance, not condemnation.</p><p>Whatever makes you afraid today â€” an uncertain future, a health concern, a broken relationship â€” hear God say to you: \"Do not be afraid.\" The One who conquered death is with you. There is nothing you will face that He has not already overcome.</p>",
+      "pray": "<p>Father, I confess my fears to You. I choose to trust the risen Christ rather than my circumstances. Replace my fear with faith, my anxiety with peace, and my doubt with confidence in Your promises. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Every time fear rises today, pause and whisper: \"He is risen. I do not need to be afraid.\"</p>",
+      "verses": "[\"Matthew:28:5-6\",\"Isaiah:41:10\",\"2 Timothy:1:7\"]"
+    },
+    {
+      "day_number": 99,
+      "title": "The Garden and the Tomb",
+      "pause": "<p>Imagine yourself in a quiet garden at dawn. The air is cool, the birds are beginning to sing. Jesus is near. Rest in His presence.</p>",
+      "listen": "<p>\"Now Mary stood outside the tomb crying... She turned around and saw Jesus standing there, but she did not realize that it was Jesus. He asked her, 'Woman, why are you crying? Who is it you are looking for?'\"</p><span class=\"verse-ref\">John 20:11,14-15</span>",
+      "think": "<p>Mary Magdalene came to the tomb weeping, certain that all hope was lost. She was so consumed by grief that she did not recognize Jesus standing right in front of her. It was only when He spoke her name that her eyes were opened.</p><p>Sometimes our pain can blind us to God's presence. He is closer than you think â€” often standing right beside you in your darkest moment. Listen for His voice. He knows your name, and He is calling you out of sorrow into joy.</p>",
+      "pray": "<p>Jesus, open my eyes to see You even in the midst of my tears. Speak my name and remind me that You are near. Turn my mourning into dancing and my sorrow into joy. Amen.</p>",
+      "go_action": "<p>Find a quiet place today â€” even five minutes â€” and simply listen for God's voice. He may speak through Scripture, a thought, or a deep sense of peace.</p>",
+      "verses": "[\"John:20:11-16\",\"Psalm:30:5\",\"Isaiah:61:3\"]"
+    },
+    {
+      "day_number": 100,
+      "title": "Alive Forevermore",
+      "pause": "<p>This is day 100. A milestone in this year's journey with God. Pause and thank Him for every step that has brought you here.</p>",
+      "listen": "<p>\"I am the Living One; I was dead, and now look, I am alive for ever and ever! And I hold the keys of death and Hades.\"</p><span class=\"verse-ref\">Revelation 1:18</span>",
+      "think": "<p>Jesus is not a historical figure who lived and died two thousand years ago. He is the Living One â€” alive right now, reigning in glory, holding the keys of death and the grave. No other religious leader can make this claim. The tomb is empty, and our Savior lives.</p><p>Because He lives, we can face tomorrow. Because He holds the keys, death has no power over us. Every fear, every enemy, every obstacle is subject to the One who is alive forevermore.</p>",
+      "pray": "<p>Jesus, You are alive! I worship You as the Living One who holds all authority. Because You live, I have hope. Because You reign, I have peace. Thank You for the assurance of eternal life. Amen.</p>",
+      "go_action": "<p>Celebrate this milestone. Tell someone today: \"Jesus is alive, and that changes everything.\"</p>",
+      "verses": "[\"Revelation:1:18\",\"John:11:25\",\"Romans:6:9\"]"
+    },
+    {
+      "day_number": 101,
+      "title": "Doubts Do Not Disqualify You",
+      "pause": "<p>If you have ever wrestled with doubt, you are in good company. Even the disciples doubted. Come as you are â€” God welcomes honest questions.</p>",
+      "listen": "<p>\"Then he said to Thomas, 'Put your finger here; see my hands. Reach out your hand and put it into my side. Stop doubting and believe.' Thomas said to him, 'My Lord and my God!'\"</p><span class=\"verse-ref\">John 20:27-28</span>",
+      "think": "<p>Jesus did not reject Thomas for doubting. Instead, He met Thomas exactly where he was and offered the evidence he needed. God is not threatened by your questions. He is big enough to handle your doubts and patient enough to walk you through them.</p><p>Notice that Thomas's doubt, once met by the risen Christ, produced one of the most powerful confessions of faith in all of Scripture: \"My Lord and my God!\" Your wrestle with doubt may be the very thing that leads you to a deeper faith.</p>",
+      "pray": "<p>Lord, I bring my doubts and questions to You honestly. Meet me where I am. Strengthen my faith and help me to see You clearly. Like Thomas, I want to say with my whole heart: \"My Lord and my God!\" Amen.</p>",
+      "go_action": "<p>Write down one doubt or question you have been afraid to bring to God. Bring it to Him in prayer today â€” He is not offended by your honesty.</p>",
+      "verses": "[\"John:20:27-28\",\"Mark:9:24\",\"Jude:1:22\"]"
+    },
+    {
+      "day_number": 102,
+      "title": "The Road to Emmaus",
+      "pause": "<p>Think about a time when you were discouraged and confused about God's plan. Even in those moments, Jesus was walking beside you.</p>",
+      "listen": "<p>\"As they talked and discussed these things with each other, Jesus himself came up and walked along with them; but they were kept from recognizing him.\"</p><span class=\"verse-ref\">Luke 24:15-16</span>",
+      "think": "<p>Two disciples walked the road to Emmaus, heartbroken and confused after the crucifixion. They had hoped Jesus was the Messiah, but now He was dead. What they did not realize was that the risen Jesus was walking right beside them, patiently listening and teaching.</p><p>In your seasons of confusion, Jesus is not absent â€” He is present, walking alongside you. He may reveal Himself in unexpected ways: through Scripture, through a friend, or through a sudden moment of clarity. Keep walking and keep your heart open.</p>",
+      "pray": "<p>Jesus, even when I cannot see You or feel You, I choose to believe You are walking with me. Open my eyes to recognize Your presence on the road. Set my heart on fire with Your Word. Amen.</p>",
+      "go_action": "<p>Go for a walk today â€” even a short one â€” and talk to Jesus as if He were walking right beside you. He is.</p>",
+      "verses": "[\"Luke:24:15-16\",\"Luke:24:32\",\"Matthew:28:20\"]"
+    },
+    {
+      "day_number": 103,
+      "title": "Peace Be With You",
+      "pause": "<p>Inhale slowly. Exhale. Receive the peace of Christ. It is not the absence of trouble â€” it is the presence of God in the midst of trouble.</p>",
+      "listen": "<p>\"On the evening of that first day of the week, when the disciples were together, with the doors locked for fear of the Jewish leaders, Jesus came and stood among them and said, 'Peace be with you!'\"</p><span class=\"verse-ref\">John 20:19</span>",
+      "think": "<p>The disciples were hiding behind locked doors, paralyzed by fear. But locked doors are no obstacle for the risen Christ. He walked right through them and spoke peace into their terror. His first word to frightened people was not a command â€” it was a gift: <em>peace</em>.</p><p>No matter how tightly you have locked the doors of your heart out of fear, Jesus can reach you. He comes not to judge you for being afraid, but to fill you with a peace that the world cannot give and cannot take away.</p>",
+      "pray": "<p>Prince of Peace, I open the locked doors of my heart to You. Come in and fill every fearful corner with Your presence. I receive Your peace â€” not as the world gives, but as only You can give. Amen.</p>",
+      "go_action": "<p>Is there someone in your life who needs to hear \"peace be with you\" today? Send them an encouraging message or call them.</p>",
+      "verses": "[\"John:20:19\",\"John:14:27\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 104,
+      "title": "Scars That Tell a Story",
+      "pause": "<p>Look at your hands. Every line, every mark tells a story. Jesus chose to keep His scars. They are proof of a love that conquered death.</p>",
+      "listen": "<p>\"Then he said to Thomas, 'Put your finger here; see my hands. Reach out your hand and put it into my side.'\"</p><span class=\"verse-ref\">John 20:27</span>",
+      "think": "<p>When Jesus rose from the dead, He could have had a completely new, unmarked body. Instead, He kept His scars. He showed them to His disciples as proof â€” not of defeat, but of victory. His wounds are evidence that love went all the way and won.</p><p>Your scars â€” the wounds from past pain, failures, and heartbreaks â€” are not signs of weakness. In God's hands, they become a testimony. They tell the story of what you survived by His grace. Do not be ashamed of them; they are part of your resurrection story.</p>",
+      "pray": "<p>Jesus, thank You for Your scars that purchased my healing. Help me see my own wounds not as reasons for shame, but as testimonies of Your faithfulness. Use my story to encourage others. Amen.</p>",
+      "go_action": "<p>Think of a scar â€” physical or emotional â€” that God has redeemed. Thank Him for turning your pain into a testimony.</p>",
+      "verses": "[\"John:20:27\",\"2 Corinthians:12:9\",\"Psalm:147:3\"]"
+    },
+    {
+      "day_number": 105,
+      "title": "Breakfast by the Shore",
+      "pause": "<p>Picture the Sea of Galilee at dawn. A charcoal fire on the beach. The smell of fresh bread and fish. Jesus is cooking breakfast for His friends.</p>",
+      "listen": "<p>\"Jesus said to them, 'Come and have breakfast.' None of the disciples dared ask him, 'Who are you?' They knew it was the Lord.\"</p><span class=\"verse-ref\">John 21:12</span>",
+      "think": "<p>After His resurrection, Jesus did not summon His disciples to a palace or a throne room. He met them on a beach and made them breakfast. The King of Kings served fish and bread to tired, confused fishermen. This is the heart of our God â€” present in the ordinary, meeting us in our everyday needs.</p><p>God cares about the mundane details of your life. He is not only the God of miracles and grand moments. He is the God of breakfast, of daily provision, of quiet companionship by the shore.</p>",
+      "pray": "<p>Lord, thank You for meeting me in the ordinary moments. Help me to recognize Your presence in the daily routines of life â€” in meals, in conversations, in quiet mornings. You are the God of the everyday. Amen.</p>",
+      "go_action": "<p>Prepare a meal for someone today â€” a friend, a family member, a neighbor. Let it be an act of love that mirrors the heart of Jesus.</p>",
+      "verses": "[\"John:21:12\",\"John:21:15-17\",\"Psalm:23:5\"]"
+    },
+    {
+      "day_number": 106,
+      "title": "Do You Love Me?",
+      "pause": "<p>Let God ask you the same question He asked Peter: \"Do you love Me?\" Do not rush to answer. Sit with it. Let it search your heart.</p>",
+      "listen": "<p>\"When they had finished eating, Jesus said to Simon Peter, 'Simon son of John, do you love me more than these?' 'Yes, Lord,' he said, 'you know that I love you.' Jesus said, 'Feed my lambs.'\"</p><span class=\"verse-ref\">John 21:15</span>",
+      "think": "<p>Peter had denied Jesus three times. Now, the risen Jesus gave him three opportunities to reaffirm his love. This was not an interrogation â€” it was restoration. Every \"Do you love Me?\" was an invitation to replace a denial with a declaration of love.</p><p>If you have failed God, He is not keeping score. He is offering you a fresh start. He does not ask for perfection â€” He asks for love. And each time you say \"yes\" to Him, He entrusts you with greater purpose: \"Feed my sheep.\"</p>",
+      "pray": "<p>Jesus, You know all things â€” You know that I love You, even imperfectly. Thank You for restoring me after my failures. I say yes to You again today. Show me how to serve others from the overflow of that love. Amen.</p>",
+      "go_action": "<p>Has failure made you feel disqualified? Write \"He restores me\" somewhere you will see it today. Then do something kind for someone as an act of renewed purpose.</p>",
+      "verses": "[\"John:21:15-17\",\"Psalm:51:12\",\"Lamentations:3:22-23\"]"
+    },
+    {
+      "day_number": 107,
+      "title": "The Promise of the Spirit",
+      "pause": "<p>Be still. The same Holy Spirit who empowered the early church lives within you right now. Acknowledge His presence.</p>",
+      "listen": "<p>\"But you will receive power when the Holy Spirit comes on you; and you will be my witnesses in Jerusalem, and in all Judea and Samaria, and to the ends of the earth.\"</p><span class=\"verse-ref\">Acts 1:8</span>",
+      "think": "<p>Before ascending to heaven, Jesus promised His followers something extraordinary: the Holy Spirit. Not a distant force, but a personal Presence who would empower them to do things beyond their natural ability. This promise was for them â€” and it is for you.</p><p>You are not meant to live the Christian life in your own strength. The Holy Spirit is your helper, your comforter, your guide, and your source of supernatural power. Lean into Him today.</p>",
+      "pray": "<p>Holy Spirit, fill me afresh today. I cannot live this life in my own strength. I need Your power, Your guidance, and Your comfort. Empower me to be a faithful witness wherever I go. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Before making any decision today, pause and ask the Holy Spirit: \"What would You have me do?\" Then listen.</p>",
+      "verses": "[\"Acts:1:8\",\"John:14:26\",\"Romans:8:26\"]"
+    },
+    {
+      "day_number": 108,
+      "title": "Seeds Must Fall and Die",
+      "pause": "<p>Hold a seed in your mind's eye â€” small, unremarkable, lifeless in appearance. Yet within it lies an entire harvest. Be patient with what God is growing in you.</p>",
+      "listen": "<p>\"Very truly I tell you, unless a kernel of wheat falls to the ground and dies, it remains only a single seed. But if it dies, it produces many seeds.\"</p><span class=\"verse-ref\">John 12:24</span>",
+      "think": "<p>Jesus spoke these words about His own death and resurrection, but the principle extends to our lives. Growth requires letting go. Fruitfulness requires dying to self â€” to our pride, our plans, our desire for control. It is in the surrendered places that God produces the greatest harvest.</p><p>The things you are releasing right now â€” comfort, certainty, old habits â€” are seeds being planted. Trust the process. What looks like death is actually the beginning of abundant new life.</p>",
+      "pray": "<p>Lord, give me the courage to let go of what You are asking me to release. I trust that what dies in Your hands does not stay dead â€” it becomes a harvest. Help me surrender fully. Amen.</p>",
+      "go_action": "<p>Identify one thing God is asking you to let go of. Write it on a piece of paper, pray over it, and symbolically release it to God.</p>",
+      "verses": "[\"John:12:24\",\"Galatians:2:20\",\"Mark:8:35\"]"
+    },
+    {
+      "day_number": 109,
+      "title": "He Prepares a Table for You",
+      "pause": "<p>Rest. Even in the middle of your battles, God has set a table for you. You are invited to sit down and feast in His presence.</p>",
+      "listen": "<p>\"You prepare a table before me in the presence of my enemies. You anoint my head with oil; my cup overflows.\"</p><span class=\"verse-ref\">Psalm 23:5</span>",
+      "think": "<p>Notice where the table is set â€” not after the battle, but <em>in the presence of your enemies</em>. God does not wait until your problems are solved to bless you. He blesses you right in the middle of the struggle. His provision, peace, and abundance are available even in the fight.</p><p>The enemy wants you to believe you are starving and abandoned. But God has set a feast before you. Sit down. Eat. Let your cup overflow. The battle belongs to the Lord.</p>",
+      "pray": "<p>Good Shepherd, thank You for preparing a table for me even when enemies surround me. I choose to feast on Your goodness rather than focus on my problems. My cup overflows with Your blessings. Amen.</p>",
+      "go_action": "<p>Instead of worrying about a current problem, intentionally thank God for three specific blessings in your life right now.</p>",
+      "verses": "[\"Psalm:23:5\",\"Psalm:23:1-6\",\"Romans:8:37\"]"
+    },
+    {
+      "day_number": 110,
+      "title": "From Mourning to Dancing",
+      "pause": "<p>Think about a time when your heart was heavy. Now think about a time when joy returned. God is the One who turns our mourning into dancing.</p>",
+      "listen": "<p>\"You turned my wailing into dancing; you removed my sackcloth and clothed me with joy, that my heart may sing your praises and not be silent. Lord my God, I will praise you forever.\"</p><span class=\"verse-ref\">Psalm 30:11-12</span>",
+      "think": "<p>The resurrection is the ultimate picture of mourning turned to dancing. The disciples went from devastating grief on Friday to uncontainable joy on Sunday. God did not remove the pain â€” He transformed it. He walked them through it and brought them out the other side with something greater.</p><p>If you are in a season of weeping, hold on. Joy is coming. It may not come on your timeline, but it will come. God is faithful to complete the work He has started in you.</p>",
+      "pray": "<p>Father, I trust that You are turning my mourning into dancing. Even if I cannot see it yet, I believe that joy is on the way. Clothe me with gladness and let my heart sing Your praises. Amen.</p>",
+      "go_action": "<p>Put on a worship song and let yourself be moved. Sing, clap, or dance â€” even if it feels small. Choose joy today as an act of faith.</p>",
+      "verses": "[\"Psalm:30:11-12\",\"Jeremiah:31:13\",\"John:16:20\"]"
+    },
+    {
+      "day_number": 111,
+      "title": "The Cross Before the Crown",
+      "pause": "<p>Reflect on this: there is no crown without a cross, no victory without a battle, no resurrection without a crucifixion. God uses the hard places.</p>",
+      "listen": "<p>\"For the joy set before him he endured the cross, scorning its shame, and sat down at the right hand of the throne of God.\"</p><span class=\"verse-ref\">Hebrews 12:2</span>",
+      "think": "<p>Jesus endured the worst the world could throw at Him â€” betrayal, mockery, torture, death â€” because He could see beyond the cross to the joy that awaited. He kept His eyes on the eternal reward and endured the temporary suffering.</p><p>Your present difficulties are not the end of the story. Like Jesus, you can endure the hard season because there is joy set before you. Keep your eyes on what God has promised, not on what you are currently walking through.</p>",
+      "pray": "<p>Jesus, when the road is painful, help me to fix my eyes on You. Give me the strength to endure with grace, knowing that joy awaits on the other side. I trust Your process. Amen.</p>",
+      "go_action": "<p>Write Hebrews 12:2 on a card and place it where you will see it. Let it remind you that endurance leads to joy.</p>",
+      "verses": "[\"Hebrews:12:2\",\"James:1:2-4\",\"Romans:8:18\"]"
+    },
+    {
+      "day_number": 112,
+      "title": "Grafted Into the Vine",
+      "pause": "<p>Picture a vine with many branches, each one connected, each one alive because of the sap flowing from the root. You are one of those branches.</p>",
+      "listen": "<p>\"I am the vine; you are the branches. If you remain in me and I in you, you will bear much fruit; apart from me you can do nothing.\"</p><span class=\"verse-ref\">John 15:5</span>",
+      "think": "<p>A branch does not produce fruit by straining or trying harder. It produces fruit by staying connected to the vine. The life, the nutrients, the growth â€” all of it comes from the vine. The branch's only job is to remain attached.</p><p>In a world that prizes hustle and self-sufficiency, Jesus invites us to a different way: abide. Stay connected. Rest in Him. The fruit will come naturally as you remain in His love, His Word, and His presence.</p>",
+      "pray": "<p>Jesus, I want to remain in You. Forgive me for the times I have tried to produce fruit in my own strength. Teach me to abide in Your presence and trust You with the outcome. Amen.</p>",
+      "go_action": "<p>Choose one way to abide in Christ today: read a passage of Scripture slowly, spend time in prayer, or sit in silence with Him for ten minutes.</p>",
+      "verses": "[\"John:15:5\",\"John:15:4\",\"Galatians:5:22-23\"]"
+    },
+    {
+      "day_number": 113,
+      "title": "The Victory Is Already Won",
+      "pause": "<p>Take a breath. Whatever battle you are facing, the outcome has already been decided. In Christ, you are on the winning side.</p>",
+      "listen": "<p>\"But thanks be to God! He gives us the victory through our Lord Jesus Christ.\"</p><span class=\"verse-ref\">1 Corinthians 15:57</span>",
+      "think": "<p>The resurrection was God's ultimate declaration of victory. Death, sin, and the grave â€” humanity's greatest enemies â€” were defeated once and for all. This victory was not earned by our effort but given to us as a gift through Jesus Christ.</p><p>You do not fight <em>for</em> victory; you fight <em>from</em> victory. The battle has already been won on the cross. When you face temptation, discouragement, or spiritual attack, stand firm in the finished work of Christ. The enemy is already defeated.</p>",
+      "pray": "<p>Father, thank You for the victory You have already won. I do not fight from a place of fear but from a place of triumph. Help me stand firm in the truth that the battle is already Yours. In Jesus' name, Amen.</p>",
+      "go_action": "<p>Replace one negative, fearful thought today with this declaration: \"Thanks be to God, who gives me the victory through Jesus Christ.\"</p>",
+      "verses": "[\"1 Corinthians:15:57\",\"Romans:8:37\",\"1 John:5:4\"]"
+    },
+    {
+      "day_number": 114,
+      "title": "Springs of Living Water",
+      "pause": "<p>Think of a cool, flowing spring of water on a hot day. Let your soul be refreshed. Jesus offers water that never runs dry.</p>",
+      "listen": "<p>\"Whoever believes in me, as Scripture has said, rivers of living water will flow from within them.\"</p><span class=\"verse-ref\">John 7:38</span>",
+      "think": "<p>Jesus does not just quench your thirst â€” He turns you into a source of refreshment for others. The living water He gives is the Holy Spirit, flowing from within you like a river. It is not a trickle; it is an overflowing, life-giving stream.</p><p>When you abide in Christ, you naturally become a blessing to those around you. Your words bring encouragement. Your presence brings peace. Your life points others to the Source. You do not have to force it â€” just stay connected to the Spring.</p>",
+      "pray": "<p>Lord Jesus, let rivers of living water flow from within me. Fill me so full of Your Spirit that it overflows to everyone I encounter. Let my life be refreshing to others. Amen.</p>",
+      "go_action": "<p>Be a \"spring of living water\" today â€” offer a cold drink, a kind word, or practical help to someone who looks weary.</p>",
+      "verses": "[\"John:7:38\",\"John:4:14\",\"Isaiah:58:11\"]"
+    },
+    {
+      "day_number": 115,
+      "title": "He Makes All Things New",
+      "pause": "<p>Close your eyes. Think of something in your life that feels old, worn out, or broken. Now hear God whisper: \"I am making all things new.\"</p>",
+      "listen": "<p>\"He who was seated on the throne said, 'I am making everything new!' Then he said, 'Write this down, for these words are trustworthy and true.'\"</p><span class=\"verse-ref\">Revelation 21:5</span>",
+      "think": "<p>God does not just patch things up â€” He makes them <em>new</em>. Not repaired. Not refurbished. Brand new. This is the promise of the One who sits on the throne: total restoration, complete renewal, a future so beautiful that He told John to write it down because it is absolutely trustworthy.</p><p>That broken relationship, that shattered dream, that part of your life that feels beyond repair â€” God has not given up on it. He is the master Restorer, and He is working even now to bring beauty from ashes.</p>",
+      "pray": "<p>God, I believe Your promise to make all things new. I bring the broken areas of my life to You. Restore, renew, and rebuild what the enemy has tried to destroy. I trust Your faithful words. Amen.</p>",
+      "go_action": "<p>Take something broken â€” a strained friendship, a neglected goal, a forgotten dream â€” and take one small step toward renewal today.</p>",
+      "verses": "[\"Revelation:21:5\",\"Isaiah:61:3\",\"Joel:2:25\"]"
+    },
+    {
+      "day_number": 116,
+      "title": "Forgiven and Set Free",
+      "pause": "<p>Let go of the guilt. Let go of the shame. Christ has already paid the price. You are forgiven. Receive it.</p>",
+      "listen": "<p>\"Therefore, there is now no condemnation for those who are in Christ Jesus, because through Christ Jesus the law of the Spirit who gives life has set you free from the law of sin and death.\"</p><span class=\"verse-ref\">Romans 8:1-2</span>",
+      "think": "<p>No condemnation. Not \"less condemnation\" or \"condemnation on good days.\" <em>No</em> condemnation â€” none at all â€” for those who are in Christ. The gavel has come down, and the verdict is: free. The law of the Spirit of life has broken the chains of sin and death.</p><p>If the enemy whispers that you are still guilty, remind him of the cross. If your own heart condemns you, remember that God is greater than your heart. You are not defined by your worst moment. You are defined by Christ's best moment â€” His sacrifice for you.</p>",
+      "pray": "<p>Father, I receive Your forgiveness today. I refuse to live under condemnation when Christ has set me free. Help me to walk in the freedom You purchased for me and to extend that same grace to others. Amen.</p>",
+      "go_action": "<p>If you have been carrying guilt over a confessed sin, write it down and then cross it out. Write over it: \"No condemnation â€” Romans 8:1.\" Let it go.</p>",
+      "verses": "[\"Romans:8:1-2\",\"1 John:1:9\",\"Psalm:103:12\"]"
+    },
+    {
+      "day_number": 117,
+      "title": "The Good Shepherd Leads",
+      "pause": "<p>Sheep do not need to know the entire path. They only need to know the Shepherd's voice. Listen for His voice today.</p>",
+      "listen": "<p>\"My sheep listen to my voice; I know them, and they follow me. I give them eternal life, and they shall never perish; no one will snatch them out of my hand.\"</p><span class=\"verse-ref\">John 10:27-28</span>",
+      "think": "<p>Jesus describes a beautiful, intimate relationship between a shepherd and his sheep. He knows you â€” not just your name, but your heart, your struggles, your dreams. And you can know His voice â€” distinct, trustworthy, leading you to green pastures and still waters.</p><p>In a world full of competing voices, learn to distinguish the Shepherd's voice. He will never lead you into danger. He will never abandon you. And nothing â€” absolutely nothing â€” can snatch you from His hand.</p>",
+      "pray": "<p>Good Shepherd, tune my ears to Your voice above all the noise. I trust You to lead me on the right path. Thank You that I am secure in Your hand and that nothing can take me from You. Amen.</p>",
+      "go_action": "<p>Practice listening to God today. Before each major moment â€” a meeting, a conversation, a decision â€” ask: \"Shepherd, what do You want me to know?\"</p>",
+      "verses": "[\"John:10:27-28\",\"Psalm:23:1-3\",\"Isaiah:30:21\"]"
+    },
+    {
+      "day_number": 118,
+      "title": "Clothed in Righteousness",
+      "pause": "<p>Imagine removing heavy, dirty garments and being clothed in pure, white robes. This is what Christ has done for you. Receive it.</p>",
+      "listen": "<p>\"I delight greatly in the Lord; my soul rejoices in my God. For he has clothed me with garments of salvation and arrayed me in a robe of his righteousness.\"</p><span class=\"verse-ref\">Isaiah 61:10</span>",
+      "think": "<p>You cannot earn righteousness by your own efforts. It is a gift â€” a robe that God Himself wraps around you. When He looks at you, He does not see your failures and stains. He sees you clothed in the righteousness of Christ, beautiful and blameless.</p><p>Stop trying to clean yourself up before coming to God. He is the one who clothes you. Come as you are, and let Him dress you in salvation and righteousness. Then walk in the confidence that you are already accepted and loved.</p>",
+      "pray": "<p>Lord, I am grateful that my righteousness comes from You and not from my own works. Thank You for clothing me in salvation. Help me walk today in the confidence of who I am in Christ. Amen.</p>",
+      "go_action": "<p>The next time you feel \"not good enough,\" remember: you are clothed in His righteousness. Speak it: \"I am righteous in Christ â€” not by my works, but by His grace.\"</p>",
+      "verses": "[\"Isaiah:61:10\",\"2 Corinthians:5:21\",\"Philippians:3:9\"]"
+    },
+    {
+      "day_number": 119,
+      "title": "Hope That Does Not Disappoint",
+      "pause": "<p>Whatever has disappointed you â€” a broken promise, an unmet expectation, a delayed dream â€” know this: the hope God gives will never put you to shame.</p>",
+      "listen": "<p>\"And hope does not put us to shame, because God's love has been poured out into our hearts through the Holy Spirit, who has been given to us.\"</p><span class=\"verse-ref\">Romans 5:5</span>",
+      "think": "<p>Worldly hope is uncertain â€” it depends on circumstances, people, and timing. But the hope we have in Christ is anchored in something unshakeable: God's love, poured into our hearts by the Holy Spirit. This hope is not wishful thinking; it is confident expectation based on God's character.</p><p>Even when life disappoints, God never does. His promises are yes and amen in Christ. The hope He gives is not fragile â€” it is an anchor for the soul, firm and secure. Hold fast to it.</p>",
+      "pray": "<p>Father, pour out Your love afresh in my heart today. Anchor my hope in Your promises, not in my circumstances. Thank You that the hope You give will never disappoint. I trust You. Amen.</p>",
+      "go_action": "<p>Encourage someone who is losing hope today. Share a Bible verse or a word of encouragement. Be a carrier of the hope that does not disappoint.</p>",
+      "verses": "[\"Romans:5:5\",\"Hebrews:6:19\",\"Jeremiah:29:11\"]"
+    },
+    {
+      "day_number": 120,
+      "title": "Living as Resurrection People",
+      "pause": "<p>As this month draws to a close, sit with this truth: you serve a risen Savior. Because of the resurrection, everything has changed. You are alive in Christ.</p>",
+      "listen": "<p>\"Since, then, you have been raised with Christ, set your hearts on things above, where Christ is, seated at the right hand of God. Set your minds on things above, not on earthly things.\"</p><span class=\"verse-ref\">Colossians 3:1-2</span>",
+      "think": "<p>The resurrection is not just an event we celebrate once a year â€” it is a reality we live in every single day. Because Christ was raised, we too have been raised to new life. Our perspective should be shaped by eternity, not just by the temporary circumstances we see around us.</p><p>As resurrection people, we live with hope in despair, peace in chaos, joy in suffering, and love in hatred. We are citizens of heaven, living with purpose on earth. Let this truth shape every decision, every relationship, and every moment of this day.</p>",
+      "pray": "<p>Risen Lord, help me to live each day as a resurrection person. Set my heart and mind on things above. Let the reality of Your resurrection transform how I see the world and how I walk through it. In Your powerful name, Amen.</p>",
+      "go_action": "<p>Reflect on this month's journey through the resurrection theme. Write down the one truth that impacted you the most. Carry it into the months ahead.</p>",
+      "verses": "[\"Colossians:3:1-2\",\"Ephesians:2:6\",\"Romans:6:4\"]"
+    },
+    {
+      "day_number": 121,
+      "title": "Morning Mercies",
+      "pause": "<p>Before the noise of the day begins, be still. God has already met you here with fresh mercy.</p>",
+      "listen": "<p>\"Because of the Lord's great love we are not consumed, for his compassions never fail. They are new every morning; great is your faithfulness.\"</p><span class=\"verse-ref\">Lamentations 3:22-23</span>",
+      "think": "<p>We do not begin the day empty-handed. Before we pray the first prayer or make the first decision, God has already provided mercy for this day. Yesterday's failures do not get the final word. Today begins under the faithfulness of God.</p><p>His mercies are not recycled leftovers. They are new every morning, fitted for today's needs, today's burdens, and today's opportunities. You can walk forward with confidence because His compassion has already gone before you.</p>",
+      "pray": "<p>Faithful God, thank You for new mercies this morning. I receive Your compassion for this day and release yesterday into Your hands. Help me walk in fresh grace and renewed trust. Amen.</p>",
+      "go_action": "<p>Begin today by thanking God for three fresh mercies you can already see.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:5:3\",\"Isaiah:33:2\"]"
+    },
+    {
+      "day_number": 122,
+      "title": "Ask for Wisdom",
+      "pause": "<p>Bring your unanswered questions to God. He does not shame those who ask for help.</p>",
+      "listen": "<p>\"If any of you lacks wisdom, you should ask God, who gives generously to all without finding fault, and it will be given to you.\"</p><span class=\"verse-ref\">James 1:5</span>",
+      "think": "<p>Many of us ask God for strength, provision, or direction, yet forget to ask for wisdom. But wisdom is one of the clearest promises in Scripture. God gives it generously, not reluctantly. He is not irritated by your need for guidance; He welcomes it.</p><p>Wisdom helps you respond rather than react, discern rather than drift, and obey rather than guess. When you are unsure what to do next, begin by asking the God who delights to guide His children.</p>",
+      "pray": "<p>Lord, I need Your wisdom today. Show me how to think, speak, and act in ways that honor You. Guard me from leaning on my own understanding, and teach me to walk in Your counsel. Amen.</p>",
+      "go_action": "<p>Write down one decision you need wisdom for and pray over it before doing anything else.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 123,
+      "title": "Abide, Do Not Strive",
+      "pause": "<p>Take a slow breath. God is not asking you to manufacture fruit in your own strength.</p>",
+      "listen": "<p>\"Remain in me, as I also remain in you. No branch can bear fruit by itself; it must remain in the vine.\"</p><span class=\"verse-ref\">John 15:4</span>",
+      "think": "<p>We often treat spiritual growth like a personal project to manage. Yet Jesus gives a different invitation: remain. Fruit grows from connection, not anxiety. A branch does not become fruitful by clenching harder, but by staying joined to the vine.</p><p>If you feel spiritually dry, the answer is not more striving. It is deeper abiding. Stay close through prayer, Scripture, obedience, and quiet trust. The life of Christ in you will accomplish what pressure never can.</p>",
+      "pray": "<p>Jesus, keep me close to You. Forgive me for striving in places where You are calling me to abide. Root me in Your presence so that real fruit grows from my life. Amen.</p>",
+      "go_action": "<p>Set aside ten quiet minutes today simply to sit with God without rushing to perform.</p>",
+      "verses": "[\"John:15:4\",\"Psalm:1:2-3\",\"Galatians:5:22-23\"]"
+    },
+    {
+      "day_number": 124,
+      "title": "Peace for the Mind",
+      "pause": "<p>Lay your racing thoughts before the Lord. He cares about the inner noise you carry.</p>",
+      "listen": "<p>\"You will keep in perfect peace those whose minds are steadfast, because they trust in you.\"</p><span class=\"verse-ref\">Isaiah 26:3</span>",
+      "think": "<p>Peace is not produced by controlling every outcome. It is the fruit of fixing your mind on the One who does not change. When your thoughts scatter, your soul often follows. But when you return your mind to God, peace begins to steady your heart.</p><p>Perfect peace does not mean a trouble-free life. It means a held life. God can keep what you entrust to Him, including your thoughts, fears, and unanswered concerns.</p>",
+      "pray": "<p>God of peace, steady my mind today. Draw my thoughts back to Your truth whenever anxiety rises. I choose to trust You more than I trust my own worries. Amen.</p>",
+      "go_action": "<p>When anxious thoughts come today, pause and repeat: \"You will keep in perfect peace...\"</p>",
+      "verses": "[\"Isaiah:26:3\",\"Philippians:4:6-7\",\"2 Corinthians:10:5\"]"
+    },
+    {
+      "day_number": 125,
+      "title": "Faithful in Small Things",
+      "pause": "<p>Do not overlook the ordinary assignments in front of you. God sees hidden faithfulness.</p>",
+      "listen": "<p>\"Whoever can be trusted with very little can also be trusted with much...\"</p><span class=\"verse-ref\">Luke 16:10</span>",
+      "think": "<p>We often want visible impact while neglecting quiet obedience. But God builds lives of weight through small acts of faithfulness repeated over time. Integrity in private, kindness in routine moments, and diligence in simple tasks matter deeply to Him.</p><p>The small thing in your hand today may be the training ground for tomorrow's assignment. Do not despise the ordinary. God often measures greatness by faithfulness, not by attention.</p>",
+      "pray": "<p>Lord, make me faithful in the small things. Help me serve with integrity when no one is watching and obey with joy even in ordinary moments. Shape my character through daily faithfulness. Amen.</p>",
+      "go_action": "<p>Choose one small responsibility today and do it wholeheartedly as an act of worship.</p>",
+      "verses": "[\"Luke:16:10\",\"Colossians:3:23\",\"Zechariah:4:10\"]"
+    },
+    {
+      "day_number": 126,
+      "title": "God Gives Rest",
+      "pause": "<p>Let your soul unclench. You are allowed to rest in the care of God.</p>",
+      "listen": "<p>\"Come to me, all you who are weary and burdened, and I will give you rest.\"</p><span class=\"verse-ref\">Matthew 11:28</span>",
+      "think": "<p>Jesus does not merely command weary people to keep going; He invites them to come. Rest is not weakness. It is trust. It is the refusal to live as though everything depends on your effort.</p><p>There is a rest deeper than sleep: the rest of handing your burden to Christ. You may still have responsibilities, but you do not have to carry them alone. The gentle Savior knows how to hold what exhausts you.</p>",
+      "pray": "<p>Jesus, I come to You with the weight I have been carrying. Give rest to my soul and teach me the unforced rhythm of grace. Help me receive Your peace today. Amen.</p>",
+      "go_action": "<p>Make one practical choice today that honors rest rather than hurry.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Hebrews:4:9-10\"]"
+    },
+    {
+      "day_number": 127,
+      "title": "Quick to Listen",
+      "pause": "<p>Slow your words and quiet your reactions. Invite God to shape how you listen.</p>",
+      "listen": "<p>\"Everyone should be quick to listen, slow to speak and slow to become angry.\"</p><span class=\"verse-ref\">James 1:19</span>",
+      "think": "<p>Many conflicts are not caused by lack of words, but by lack of listening. Scripture calls us into a holy slowness: quick to listen, slow to speak, slow to anger. This is more than good advice; it is Spirit-formed wisdom.</p><p>Listening is an act of humility. It makes room for understanding, softens impulsive reactions, and reflects the patience of Christ. When you listen well, you love well.</p>",
+      "pray": "<p>Father, teach me to listen before I react. Guard my mouth, soften my tone, and slow my anger. Let my words today be marked by grace and wisdom. Amen.</p>",
+      "go_action": "<p>In your next conversation, focus on understanding first instead of preparing your reply.</p>",
+      "verses": "[\"James:1:19\",\"Proverbs:15:1\",\"Ephesians:4:29\"]"
+    },
+    {
+      "day_number": 128,
+      "title": "Strength for Today",
+      "pause": "<p>You do not need tomorrow's strength today. God supplies what this day requires.</p>",
+      "listen": "<p>\"My grace is sufficient for you, for my power is made perfect in weakness.\"</p><span class=\"verse-ref\">2 Corinthians 12:9</span>",
+      "think": "<p>Weakness often feels like failure, yet Paul learned that it can become the very place where the power of Christ rests most clearly. God's grace is not theoretical support. It is active strength for present need.</p><p>You may feel inadequate for what is in front of you, but God has never depended on your adequacy. He delights to display His sufficiency in surrendered weakness. Bring Him your limits and watch what grace can do.</p>",
+      "pray": "<p>Lord, I confess my weakness to You without shame. Let Your power be made perfect in me today. I receive the grace that is sufficient for this moment. Amen.</p>",
+      "go_action": "<p>Name one area where you feel weak and specifically invite God's strength into it.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Isaiah:40:29-31\",\"Philippians:4:13\"]"
+    },
+    {
+      "day_number": 129,
+      "title": "Guard Your Heart",
+      "pause": "<p>Pause long enough to notice what has been shaping your inner life lately.</p>",
+      "listen": "<p>\"Above all else, guard your heart, for everything you do flows from it.\"</p><span class=\"verse-ref\">Proverbs 4:23</span>",
+      "think": "<p>Your heart is not a minor detail in your life with God. It is the wellspring from which your words, desires, choices, and habits flow. What you repeatedly allow into your heart will eventually appear in your life.</p><p>Guarding your heart is not fearful isolation; it is wise stewardship. Pay attention to what nourishes your soul and what drains it. Let truth, worship, and godly influences shape what lives within you.</p>",
+      "pray": "<p>God, help me guard my heart with wisdom. Expose whatever is shaping me away from You, and plant in me what is pure, steady, and life-giving. Amen.</p>",
+      "go_action": "<p>Remove one unhealthy influence from your day and replace it with Scripture or worship.</p>",
+      "verses": "[\"Proverbs:4:23\",\"Philippians:4:8\",\"Psalm:119:11\"]"
+    },
+    {
+      "day_number": 130,
+      "title": "The Lord Is Near",
+      "pause": "<p>Whatever feels distant or unclear, let this truth come close: the Lord is near.</p>",
+      "listen": "<p>\"The Lord is near to all who call on him, to all who call on him in truth.\"</p><span class=\"verse-ref\">Psalm 145:18</span>",
+      "think": "<p>God is not difficult to reach. He is near to those who call on Him in truth, with sincerity and dependence. You do not need polished words or perfect emotions. Honest prayer is enough.</p><p>His nearness is one of the deepest comforts in the Christian life. In loneliness, confusion, temptation, or grief, you are not abandoned to your own strength. Call on Him, and trust that He is present.</p>",
+      "pray": "<p>Near God, thank You that You are close when I call. Teach me to come to You honestly and often. Let the awareness of Your presence steady my heart today. Amen.</p>",
+      "go_action": "<p>Take a few one-minute prayer pauses throughout the day to simply say, \"Lord, You are near.\"</p>",
+      "verses": "[\"Psalm:145:18\",\"Deuteronomy:4:7\",\"James:4:8\"]"
+    },
+    {
+      "day_number": 131,
+      "title": "Led by the Spirit",
+      "pause": "<p>Before you rush ahead, ask the Holy Spirit to lead your next step.</p>",
+      "listen": "<p>\"Since we live by the Spirit, let us keep in step with the Spirit.\"</p><span class=\"verse-ref\">Galatians 5:25</span>",
+      "think": "<p>The Christian life is more than avoiding wrong; it is walking in step with the Spirit. This means paying attention to His promptings, yielding our impulses, and learning a pace of obedience that stays close to Him.</p><p>The Spirit does not merely correct you after the fact. He leads you in the moment, giving restraint where needed and courage where required. Stay responsive. A yielded heart becomes a guided life.</p>",
+      "pray": "<p>Holy Spirit, help me keep in step with You today. Make me sensitive to Your guidance, quick to obey, and willing to slow down when You say wait. Lead me in the way of Christ. Amen.</p>",
+      "go_action": "<p>Before one key decision today, pause and ask the Spirit to lead you instead of reacting immediately.</p>",
+      "verses": "[\"Galatians:5:25\",\"Romans:8:14\",\"John:16:13\"]"
+    },
+    {
+      "day_number": 132,
+      "title": "Kindness Is Strength",
+      "pause": "<p>Consider the people you will meet today. Ask God to make your heart gentle.</p>",
+      "listen": "<p>\"Be kind and compassionate to one another, forgiving each other, just as in Christ God forgave you.\"</p><span class=\"verse-ref\">Ephesians 4:32</span>",
+      "think": "<p>Kindness is not weakness. It is strength governed by grace. In a harsh world, kindness reflects the character of Christ in practical and powerful ways. It softens tension, dignifies people, and reminds the heart of God.</p><p>Forgiven people are called to become forgiving people. The kindness you extend today may be the very thing that opens a weary heart to hope.</p>",
+      "pray": "<p>Lord, make me kind in word, patient in tone, and compassionate in spirit. Help me reflect the mercy You have shown me, especially when it costs me something. Amen.</p>",
+      "go_action": "<p>Offer one intentional act of kindness today with no desire for recognition.</p>",
+      "verses": "[\"Ephesians:4:32\",\"Colossians:3:12\",\"Proverbs:21:21\"]"
+    },
+    {
+      "day_number": 133,
+      "title": "Do Not Grow Weary",
+      "pause": "<p>If your heart feels tired from doing good, bring that weariness to God.</p>",
+      "listen": "<p>\"Let us not become weary in doing good, for at the proper time we will reap a harvest if we do not give up.\"</p><span class=\"verse-ref\">Galatians 6:9</span>",
+      "think": "<p>Weariness often comes when faithfulness seems unnoticed or fruit seems delayed. Yet Scripture reminds us that there is a proper time for harvest. God sees the seeds you keep planting, the prayers you keep praying, and the obedience you keep choosing.</p><p>Do not let discouragement convince you that perseverance is pointless. The field may look quiet, but God is still at work beneath the surface. Keep going.</p>",
+      "pray": "<p>Father, strengthen me where I have grown tired. Renew my courage to keep doing good without losing heart. Help me trust that You will bring fruit in Your time. Amen.</p>",
+      "go_action": "<p>Recommit today to one good and godly thing you have been tempted to stop doing.</p>",
+      "verses": "[\"Galatians:6:9\",\"1 Corinthians:15:58\",\"Hebrews:10:36\"]"
+    },
+    {
+      "day_number": 134,
+      "title": "A Lamp for Your Feet",
+      "pause": "<p>You do not need the whole roadmap right now. Let God light the next step.</p>",
+      "listen": "<p>\"Your word is a lamp for my feet, a light on my path.\"</p><span class=\"verse-ref\">Psalm 119:105</span>",
+      "think": "<p>God's Word often works like a lamp, not a floodlight. It gives enough light for the step in front of you, not always the full picture. This requires trust. We want clarity for the whole journey, but God often offers guidance one obedient step at a time.</p><p>When Scripture shapes your path, confusion begins to lose its control. Keep returning to the Word. It will steady your feet and form your discernment.</p>",
+      "pray": "<p>Lord, let Your Word guide me today. Illuminate the next right step and keep me from wandering in my own understanding. Give me a heart that listens and obeys. Amen.</p>",
+      "go_action": "<p>Read one short passage of Scripture slowly today and ask, \"What is my next step of obedience?\"</p>",
+      "verses": "[\"Psalm:119:105\",\"Joshua:1:8\",\"2 Timothy:3:16-17\"]"
+    },
+    {
+      "day_number": 135,
+      "title": "Prayer Changes the Atmosphere",
+      "pause": "<p>Before you face the situation, invite God into it through prayer.</p>",
+      "listen": "<p>\"The prayer of a righteous person is powerful and effective.\"</p><span class=\"verse-ref\">James 5:16</span>",
+      "think": "<p>Prayer is not a last resort for helpless people; it is a first response for dependent people. It does not merely comfort the heart. It invites the rule and help of God into real situations. Prayer changes us, but it also changes what happens around us.</p><p>Do not underestimate a quiet prayer whispered in faith. Heaven hears. God works. What seems small in the moment can become powerful in His hands.</p>",
+      "pray": "<p>Lord, teach me to turn to prayer quickly and confidently. Strengthen my faith to believe that You hear and act. Let prayer become a steady rhythm in my life. Amen.</p>",
+      "go_action": "<p>Pray immediately about one issue you have only been worrying about.</p>",
+      "verses": "[\"James:5:16\",\"Philippians:4:6\",\"1 Thessalonians:5:17\"]"
+    },
+    {
+      "day_number": 136,
+      "title": "Content in Christ",
+      "pause": "<p>Release the pressure to have more, be more, or prove more. Christ is enough.</p>",
+      "listen": "<p>\"I have learned the secret of being content in any and every situation...\"</p><span class=\"verse-ref\">Philippians 4:12</span>",
+      "think": "<p>Contentment is not found in ideal circumstances, but in a stable center. Paul learned contentment not because life was easy, but because Christ was sufficient. The heart that is anchored in Jesus is less controlled by comparison, envy, or fear.</p><p>Contentment does not mean passivity. It means receiving today as a place where God is present and enough. From that place, gratitude grows.</p>",
+      "pray": "<p>Jesus, teach me the secret of contentment. Free me from comparison and restless striving. Help me find my security and joy in You above all else. Amen.</p>",
+      "go_action": "<p>List five gifts from God in your present season and thank Him for each one.</p>",
+      "verses": "[\"Philippians:4:11-13\",\"Hebrews:13:5\",\"Psalm:16:5-6\"]"
+    },
+    {
+      "day_number": 137,
+      "title": "God Hears the Brokenhearted",
+      "pause": "<p>If your heart is heavy, do not rush past that pain. Bring it honestly before God.</p>",
+      "listen": "<p>\"The Lord is close to the brokenhearted and saves those who are crushed in spirit.\"</p><span class=\"verse-ref\">Psalm 34:18</span>",
+      "think": "<p>God does not move away from the brokenhearted. He moves close. Where others may not understand your grief, the Lord meets you with tender nearness. He is not impatient with pain. He is compassionate in it.</p><p>You do not have to clean up your sorrow before you come to Him. Bring your crushed spirit as it is. He knows how to hold what hurts.</p>",
+      "pray": "<p>Lord, draw near to me in every place of pain. Hold my heart, steady my thoughts, and remind me that I am not alone. Thank You for being close when I feel weak. Amen.</p>",
+      "go_action": "<p>Give God honest words for your grief today instead of hiding it behind strength.</p>",
+      "verses": "[\"Psalm:34:18\",\"Matthew:5:4\",\"2 Corinthians:1:3-4\"]"
+    },
+    {
+      "day_number": 138,
+      "title": "Serve with Joy",
+      "pause": "<p>Offer today to God again. Ask Him to make even simple service full of love.</p>",
+      "listen": "<p>\"Serve the Lord with gladness; come before him with joyful songs.\"</p><span class=\"verse-ref\">Psalm 100:2</span>",
+      "think": "<p>Service can become draining when it is driven by obligation or approval-seeking. But when it is offered to the Lord, it becomes worship. Joy grows when we remember who we are serving and why it matters.</p><p>You may not always feel excited about every task, but God can renew the spirit in which you serve. Gladness is often found not before obedience, but within it.</p>",
+      "pray": "<p>Father, renew the joy of serving You. Purify my motives and help me carry out today's work with gladness and love. Let my service point to Your goodness. Amen.</p>",
+      "go_action": "<p>Choose one act of service today and do it cheerfully as worship to God.</p>",
+      "verses": "[\"Psalm:100:2\",\"Colossians:3:23-24\",\"Mark:10:45\"]"
+    },
+    {
+      "day_number": 139,
+      "title": "Trust the Slow Work of God",
+      "pause": "<p>If growth feels slow, do not assume God is absent. He often works deeply before He works visibly.</p>",
+      "listen": "<p>\"Being confident of this, that he who began a good work in you will carry it on to completion...\"</p><span class=\"verse-ref\">Philippians 1:6</span>",
+      "think": "<p>Transformation usually happens gradually. We want immediate maturity, quick answers, and visible progress. But God often forms us through slow faithfulness, hidden roots, and patient surrender. His pace is wise.</p><p>Do not confuse unfinished with abandoned. If God began the work, He will continue it. Your growth may be quieter than you hoped, but it is not absent from His hands.</p>",
+      "pray": "<p>Lord, help me trust Your timing in my growth. Keep me from discouragement when progress feels slow, and remind me that You always finish what You begin. Amen.</p>",
+      "go_action": "<p>Notice one area where God has grown you over time, even if slowly, and thank Him for it.</p>",
+      "verses": "[\"Philippians:1:6\",\"Ecclesiastes:3:11\",\"Hebrews:12:1-2\"]"
+    },
+    {
+      "day_number": 140,
+      "title": "Courage to Obey",
+      "pause": "<p>Bring to mind the thing God has made clear but you have hesitated to do.</p>",
+      "listen": "<p>\"Be strong and courageous. Do not be afraid; do not be discouraged, for the Lord your God will be with you wherever you go.\"</p><span class=\"verse-ref\">Joshua 1:9</span>",
+      "think": "<p>Courage in Scripture is rarely the absence of fear. It is the choice to obey while trusting the presence of God. Joshua needed courage not because God was absent, but because God was with him and calling him forward.</p><p>When obedience feels costly, remember what makes courage possible: the Lord your God will be with you. His presence is greater than your fear.</p>",
+      "pray": "<p>God, give me courage to obey You fully. Where I have delayed through fear, strengthen me to move forward in faith. Thank You that You go with me. Amen.</p>",
+      "go_action": "<p>Take one concrete step today toward something God has already shown you to do.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 141,
+      "title": "Words That Give Life",
+      "pause": "<p>Before you speak today, ask God to make your words healing rather than harmful.</p>",
+      "listen": "<p>\"The tongue has the power of life and death...\"</p><span class=\"verse-ref\">Proverbs 18:21</span>",
+      "think": "<p>Words carry weight. They can wound deeply, but they can also strengthen, encourage, and restore. God calls us to speak in ways that impart grace to those who hear.</p><p>Your speech today can reflect the heart of Christ. A timely encouragement, a gentle correction, a sincere apology, or a hopeful reminder can become life-giving in God's hands.</p>",
+      "pray": "<p>Lord, place a guard over my mouth. Let my words today be truthful, gracious, and life-giving. Use my speech to build up rather than tear down. Amen.</p>",
+      "go_action": "<p>Speak one deliberate word of encouragement to someone who needs it today.</p>",
+      "verses": "[\"Proverbs:18:21\",\"Ephesians:4:29\",\"Colossians:4:6\"]"
+    },
+    {
+      "day_number": 142,
+      "title": "God Is Your Refuge",
+      "pause": "<p>When pressure rises, do not run first to panic. Run to your refuge.</p>",
+      "listen": "<p>\"God is our refuge and strength, an ever-present help in trouble.\"</p><span class=\"verse-ref\">Psalm 46:1</span>",
+      "think": "<p>A refuge is not imaginary comfort; it is real shelter in real trouble. Scripture does not deny that storms come. It declares that God is a present help within them. He is not late, distant, or unsure of how to help.</p><p>When life feels unstable, remember where you can run. The heart anchored in God has a place to stand even when the ground shakes.</p>",
+      "pray": "<p>Refuge and strength, I run to You today. Be my steady place in trouble and my calm in uncertainty. Help me trust Your presence more than I fear my circumstances. Amen.</p>",
+      "go_action": "<p>When stress spikes today, stop and pray Psalm 46:1 before doing anything else.</p>",
+      "verses": "[\"Psalm:46:1\",\"Nahum:1:7\",\"Proverbs:18:10\"]"
+    },
+    {
+      "day_number": 143,
+      "title": "Live with Integrity",
+      "pause": "<p>Invite God to search the hidden places of your life, not just the visible ones.</p>",
+      "listen": "<p>\"The integrity of the upright guides them...\"</p><span class=\"verse-ref\">Proverbs 11:3</span>",
+      "think": "<p>Integrity is wholeness. It is the alignment of inner life and outward life, private devotion and public conduct. A life of integrity may not always be the easiest path, but it is a clear one.</p><p>God honors truth in the inward being. When you walk in integrity, you are less divided inside and more available to the peace of obedience.</p>",
+      "pray": "<p>Lord, make me a person of integrity. Keep me honest in motive, faithful in action, and transparent before You. Guide me by truth in all I do. Amen.</p>",
+      "go_action": "<p>Make one honest correction today in an area where you have been tempted to cut corners.</p>",
+      "verses": "[\"Proverbs:11:3\",\"Psalm:15:1-2\",\"Titus:2:7\"]"
+    },
+    {
+      "day_number": 144,
+      "title": "The Joy of the Lord",
+      "pause": "<p>Joy is not something you have to force. It begins in the presence of God.</p>",
+      "listen": "<p>\"Do not grieve, for the joy of the Lord is your strength.\"</p><span class=\"verse-ref\">Nehemiah 8:10</span>",
+      "think": "<p>The joy of the Lord is deeper than mood and stronger than circumstances. It is a stabilizing gladness rooted in who God is. This joy strengthens weary hearts because it reminds us that God remains good, present, and worthy of trust.</p><p>You may not feel cheerful today, but you can still draw strength from the joy found in God's presence. Let His joy become your strength.</p>",
+      "pray": "<p>Father, renew holy joy in me. Lift the heaviness that has weighed down my spirit and let Your joy strengthen me from within. Amen.</p>",
+      "go_action": "<p>Spend a few minutes thanking God out loud for who He is, not just what He gives.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 145,
+      "title": "Wait with Hope",
+      "pause": "<p>Waiting can feel empty, but with God it is often full of hidden work.</p>",
+      "listen": "<p>\"I remain confident of this: I will see the goodness of the Lord in the land of the living. Wait for the Lord; be strong and take heart and wait for the Lord.\"</p><span class=\"verse-ref\">Psalm 27:13-14</span>",
+      "think": "<p>Waiting is one of the hardest forms of faith because it requires trust without visible control. Yet biblical waiting is not passive despair. It is strong-hearted confidence that God will show His goodness in His time.</p><p>What you do while you wait matters. Waiting can deepen dependence, refine desire, and train the heart in hope. Do not waste the waiting season by assuming nothing is happening.</p>",
+      "pray": "<p>Lord, strengthen my heart while I wait. Keep me from despair, impatience, or unbelief. Help me remain confident in Your goodness. Amen.</p>",
+      "go_action": "<p>Identify one area of waiting in your life and pray over it with hope instead of frustration.</p>",
+      "verses": "[\"Psalm:27:13-14\",\"Isaiah:40:31\",\"Romans:8:25\"]"
+    },
+    {
+      "day_number": 146,
+      "title": "Freely Receive, Freely Give",
+      "pause": "<p>Remember how generously God has dealt with you.</p>",
+      "listen": "<p>\"Freely you have received; freely give.\"</p><span class=\"verse-ref\">Matthew 10:8</span>",
+      "think": "<p>Grace was never meant to stop with us. What we have received from God, we are invited to extend to others: mercy, generosity, patience, truth, and care. The gospel produces open-handed people.</p><p>When you remember how much you have received, giving becomes less about loss and more about participation in the heart of God. Grace flows best through grateful hands.</p>",
+      "pray": "<p>Generous God, thank You for all I have freely received in Christ. Help me live open-handedly today, ready to give love, time, encouragement, and help where needed. Amen.</p>",
+      "go_action": "<p>Give something today without expecting anything in return.</p>",
+      "verses": "[\"Matthew:10:8\",\"2 Corinthians:9:8\",\"Acts:20:35\"]"
+    },
+    {
+      "day_number": 147,
+      "title": "His Grace Teaches You",
+      "pause": "<p>Do not think of grace as permission to stay stuck. Grace trains and transforms.</p>",
+      "listen": "<p>\"For the grace of God has appeared... It teaches us to say 'No' to ungodliness and worldly passions...\"</p><span class=\"verse-ref\">Titus 2:11-12</span>",
+      "think": "<p>Grace not only forgives; it forms. It teaches us how to live differently, turning our hearts away from what destroys and toward what reflects Christ. This means your growth is not sustained by guilt, but by grace.</p><p>Where you need change, do not begin with self-condemnation. Begin with the grace of God, which is powerful enough to both pardon and transform.</p>",
+      "pray": "<p>Lord, let Your grace teach me today. Shape my desires, strengthen my obedience, and help me say no to what pulls me away from You. Amen.</p>",
+      "go_action": "<p>Ask God to show you one pattern He wants to reshape by grace, and respond with obedience.</p>",
+      "verses": "[\"Titus:2:11-12\",\"Romans:6:14\",\"Ezekiel:36:26-27\"]"
+    },
+    {
+      "day_number": 148,
+      "title": "Blessed Are the Peacemakers",
+      "pause": "<p>Bring to mind a relationship or setting that needs peace.</p>",
+      "listen": "<p>\"Blessed are the peacemakers, for they will be called children of God.\"</p><span class=\"verse-ref\">Matthew 5:9</span>",
+      "think": "<p>Peacemaking is not avoiding tension at all costs. It is the courageous work of pursuing truth, humility, and reconciliation in ways that reflect the heart of God. Peace often requires wisdom, patience, and initiative.</p><p>As children of God, we are called not only to enjoy peace but also to carry it. Ask God how you might become an agent of peace where there has been friction or distance.</p>",
+      "pray": "<p>Father, make me a peacemaker. Give me wisdom, humility, and courage in strained relationships. Let my life reflect the reconciling heart of Christ. Amen.</p>",
+      "go_action": "<p>Take one humble step toward peace today, whether through apology, forgiveness, or a gracious conversation.</p>",
+      "verses": "[\"Matthew:5:9\",\"Romans:12:18\",\"Colossians:3:15\"]"
+    },
+    {
+      "day_number": 149,
+      "title": "Sing in the Night",
+      "pause": "<p>Even if this season feels dark, God remains worthy of worship.</p>",
+      "listen": "<p>\"About midnight Paul and Silas were praying and singing hymns to God...\"</p><span class=\"verse-ref\">Acts 16:25</span>",
+      "think": "<p>Paul and Silas did not wait for favorable conditions before worshiping. In pain and uncertainty, they prayed and sang. Their praise was not denial; it was defiant trust in the goodness and sovereignty of God.</p><p>Worship in dark places has a way of lifting your eyes above the prison walls. It does not always change the situation immediately, but it changes the atmosphere of the heart.</p>",
+      "pray": "<p>Lord, teach me to worship You even in hard places. Let prayer and praise rise from my heart when circumstances are heavy. You are worthy in every season. Amen.</p>",
+      "go_action": "<p>Play a worship song today in a moment you would normally spend worrying.</p>",
+      "verses": "[\"Acts:16:25\",\"Habakkuk:3:17-18\",\"Psalm:42:8\"]"
+    },
+    {
+      "day_number": 150,
+      "title": "Love Is the Better Way",
+      "pause": "<p>Let your heart settle on what matters most before God.</p>",
+      "listen": "<p>\"And now these three remain: faith, hope and love. But the greatest of these is love.\"</p><span class=\"verse-ref\">1 Corinthians 13:13</span>",
+      "think": "<p>Love is not sentimental weakness. It is the mature expression of a life shaped by God. Gifts matter. Knowledge matters. Discipline matters. But without love, even impressive things lose their true weight.</p><p>Ask yourself not only whether what you do is right, but whether it is rooted in love. Love is the better way because it reflects the very nature of God.</p>",
+      "pray": "<p>God of love, reorder my heart today. Let love shape my motives, guide my words, and mark my actions. Teach me to live in the better way. Amen.</p>",
+      "go_action": "<p>Choose one difficult person or situation today and intentionally respond in love.</p>",
+      "verses": "[\"1 Corinthians:13:13\",\"John:13:34-35\",\"1 John:4:7-8\"]"
+    },
+    {
+      "day_number": 151,
+      "title": "Held by Everlasting Arms",
+      "pause": "<p>At the close of this stretch of devotionals, rest in the truth that you are being held.</p>",
+      "listen": "<p>\"The eternal God is your refuge, and underneath are the everlasting arms.\"</p><span class=\"verse-ref\">Deuteronomy 33:27</span>",
+      "think": "<p>There are seasons when you feel strong, and there are seasons when you simply need to be carried. Scripture reminds us that underneath every trembling step of faith are the everlasting arms of God. You are upheld by strength older and steadier than your fears.</p><p>What holds you is not your grip on God, but His grip on you. That is why you can rest. His arms do not tire, and His care does not fail.</p>",
+      "pray": "<p>Eternal God, thank You for being my refuge and strength. When I feel weak, remind me that Your everlasting arms are underneath me. Teach me to rest in Your keeping love. Amen.</p>",
+      "go_action": "<p>End the day by placing your worries one by one into the care of God and thanking Him for holding you.</p>",
+      "verses": "[\"Deuteronomy:33:27\",\"Isaiah:46:4\",\"John:10:28-29\"]"
+    },
+    {
+      "day_number": 152,
+      "title": "Fresh Mercy at Dawn",
+      "pause": "<p>Before the rush of the day begins, remember that God's mercy has already met you here.</p>",
+      "listen": "<p>\"His mercies never come to an end; they are new every morning...\"</p><span class=\"verse-ref\">Lamentations 3:22-23</span>",
+      "think": "<p>God does not ration mercy. He renews it. Every morning is an invitation to begin again under His compassion rather than under the weight of yesterday.</p><p>You may wake with regrets, pressure, or weariness, but none of those have the final word. The faithfulness of God meets you at the start of this day with fresh mercy and steady love.</p>",
+      "pray": "<p>Father, thank You for fresh mercy today. Help me receive this day as a gift from Your faithful hand and walk in grace instead of shame. Amen.</p>",
+      "go_action": "<p>Start the day by thanking God for three specific mercies you can already see.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:90:14\",\"Isaiah:33:2\"]"
+    },
+    {
+      "day_number": 153,
+      "title": "Strength for the Weary",
+      "pause": "<p>If you feel tired in body or soul, do not pretend otherwise. Bring that weariness to God.</p>",
+      "listen": "<p>\"He gives strength to the weary and increases the power of the weak.\"</p><span class=\"verse-ref\">Isaiah 40:29</span>",
+      "think": "<p>God does not ask the weary to manufacture their own strength. He gives it. His help is not reserved for the naturally strong, but for those who know they need Him.</p><p>Weakness is not the end of the story. It can become the place where divine strength is most clearly known. Bring your fatigue honestly to the Lord and let Him sustain you.</p>",
+      "pray": "<p>Lord, I need Your strength today. Meet me in my weakness, renew what is worn down, and help me keep going with grace. Amen.</p>",
+      "go_action": "<p>Pause once today and ask God specifically for strength before the next task.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Matthew:11:28\"]"
+    },
+    {
+      "day_number": 154,
+      "title": "A Quiet Heart",
+      "pause": "<p>Let the noise settle. You do not have to carry every thought at full volume.</p>",
+      "listen": "<p>\"Be still, and know that I am God...\"</p><span class=\"verse-ref\">Psalm 46:10</span>",
+      "think": "<p>Stillness is not wasted time. It is space where the heart remembers who God is. In a loud and hurried world, stillness becomes an act of trust.</p><p>You do not need to solve everything in this moment. You need to know God in this moment. A quiet heart often sees more clearly than a frantic one.</p>",
+      "pray": "<p>God, quiet what is restless in me. Help me be still before You and trust Your rule over what I cannot control. Amen.</p>",
+      "go_action": "<p>Take two quiet minutes today with no phone, no music, and no agenda except being present with God.</p>",
+      "verses": "[\"Psalm:46:10\",\"Psalm:131:2\",\"Mark:6:31\"]"
+    },
+    {
+      "day_number": 155,
+      "title": "Honor in the Ordinary",
+      "pause": "<p>Do not despise ordinary responsibilities. God often works through quiet faithfulness.</p>",
+      "listen": "<p>\"Whoever can be trusted with very little can also be trusted with much...\"</p><span class=\"verse-ref\">Luke 16:10</span>",
+      "think": "<p>We often want the significant assignment while overlooking the significance of today's small obedience. But God sees what is hidden, repetitive, and unnoticed.</p><p>Faithfulness in little things forms the heart for larger things. The ordinary task in front of you can become holy ground when it is offered to God with sincerity.</p>",
+      "pray": "<p>Lord, make me faithful in the small things today. Keep me steady, sincere, and wholehearted in what You have placed before me. Amen.</p>",
+      "go_action": "<p>Choose one small task today and do it carefully as an offering to God.</p>",
+      "verses": "[\"Luke:16:10\",\"Zechariah:4:10\",\"Colossians:3:23\"]"
+    },
+    {
+      "day_number": 156,
+      "title": "When Wisdom Is Needed",
+      "pause": "<p>If you are facing a decision, invite God into it before leaning on your own understanding.</p>",
+      "listen": "<p>\"If any of you lacks wisdom, you should ask God... and it will be given to you.\"</p><span class=\"verse-ref\">James 1:5</span>",
+      "think": "<p>Wisdom is more than information. It is Spirit-shaped discernment for real-life choices. God delights to give that wisdom to those who ask in faith.</p><p>You do not have to navigate every complexity alone. Ask God for light, then walk in the clarity He gives, one obedient step at a time.</p>",
+      "pray": "<p>Father, I ask You for wisdom today. Show me what is true, what is timely, and what is pleasing to You. Amen.</p>",
+      "go_action": "<p>Before making one decision today, stop and pray specifically for wisdom.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 157,
+      "title": "Kept in Perfect Peace",
+      "pause": "<p>Bring your anxious thoughts into the presence of God instead of letting them lead you.</p>",
+      "listen": "<p>\"You will keep in perfect peace those whose minds are steadfast, because they trust in you.\"</p><span class=\"verse-ref\">Isaiah 26:3</span>",
+      "think": "<p>Peace grows where trust is practiced. A steadfast mind is not a mind with no troubles; it is a mind that keeps returning to God.</p><p>When your thoughts scatter, gently bring them back to the Lord. Trust is not a single dramatic act. It is often a quiet returning again and again to the One who keeps you.</p>",
+      "pray": "<p>God of peace, steady my mind today. Teach me to trust You more than the stories fear tries to tell me. Amen.</p>",
+      "go_action": "<p>When anxiety rises, repeat Isaiah 26:3 slowly as a prayer.</p>",
+      "verses": "[\"Isaiah:26:3\",\"Philippians:4:8-9\",\"John:14:27\"]"
+    },
+    {
+      "day_number": 158,
+      "title": "Planted by Streams",
+      "pause": "<p>Picture a tree rooted near water, steady and nourished. That is what God desires for your life.</p>",
+      "listen": "<p>\"That person is like a tree planted by streams of water...\"</p><span class=\"verse-ref\">Psalm 1:3</span>",
+      "think": "<p>Fruitfulness does not come from frantic effort alone. It comes from where your roots are planted. A soul nourished by God's Word and presence can remain steady even in dry seasons.</p><p>If you want a healthy life, tend the hidden roots. Return to the source that truly sustains you.</p>",
+      "pray": "<p>Lord, plant me deeply in Your truth. Let my life draw strength from Your presence and bear fruit in its proper season. Amen.</p>",
+      "go_action": "<p>Spend a few minutes in Scripture today with the goal of being nourished, not rushed.</p>",
+      "verses": "[\"Psalm:1:3\",\"Jeremiah:17:7-8\",\"John:15:5\"]"
+    },
+    {
+      "day_number": 159,
+      "title": "Grace for Today",
+      "pause": "<p>You do not need tomorrow's grace yet. Ask God for what this day requires.</p>",
+      "listen": "<p>\"My grace is sufficient for you, for my power is made perfect in weakness.\"</p><span class=\"verse-ref\">2 Corinthians 12:9</span>",
+      "think": "<p>We often exhaust ourselves borrowing worry from the future. But God's grace is given in the present, right where obedience is needed now.</p><p>Sufficient grace means there will be enough for today's burdens, today's choices, and today's weakness. Receive what God gives for this day, and trust Him with the next one when it comes.</p>",
+      "pray": "<p>Jesus, thank You that Your grace is enough for today. Keep me from anxious striving and teach me to lean on Your strength. Amen.</p>",
+      "go_action": "<p>Name one burden you have been carrying from the future and release it to God today.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Matthew:6:34\",\"Hebrews:4:16\"]"
+    },
+    {
+      "day_number": 160,
+      "title": "The Gift of Counsel",
+      "pause": "<p>Stay teachable before God. He knows how to guide the willing heart.</p>",
+      "listen": "<p>\"I will instruct you and teach you in the way you should go...\"</p><span class=\"verse-ref\">Psalm 32:8</span>",
+      "think": "<p>God is not silent toward His children. He leads through Scripture, wisdom, conviction, and the steady shaping of the Spirit. Guidance is often clearer for the heart that is willing to obey.</p><p>Instead of demanding the whole map, ask God for the next faithful step. He is a good guide.</p>",
+      "pray": "<p>Father, instruct me today. Make me responsive to Your counsel and ready to follow wherever You lead. Amen.</p>",
+      "go_action": "<p>Ask God for the next right step in one area where you need direction, then write it down.</p>",
+      "verses": "[\"Psalm:32:8\",\"Isaiah:30:21\",\"Proverbs:16:9\"]"
+    },
+    {
+      "day_number": 161,
+      "title": "Hope That Anchors",
+      "pause": "<p>When emotions rise and circumstances shift, remember that your hope has an anchor.</p>",
+      "listen": "<p>\"We have this hope as an anchor for the soul, firm and secure...\"</p><span class=\"verse-ref\">Hebrews 6:19</span>",
+      "think": "<p>Biblical hope is not wishful thinking. It is settled confidence in the promises and character of God. That kind of hope stabilizes the soul.</p><p>The winds may still blow, but an anchored life does not drift as easily. Let your hope rest not in outcomes you can see, but in the God who does not change.</p>",
+      "pray": "<p>God, anchor my heart in Your promises today. Keep me steady when emotions pull and circumstances feel uncertain. Amen.</p>",
+      "go_action": "<p>Write down one promise of God you need to hold onto this week.</p>",
+      "verses": "[\"Hebrews:6:19\",\"Romans:15:13\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 162,
+      "title": "Gentleness in Response",
+      "pause": "<p>Before you answer quickly, invite the Spirit to shape your tone.</p>",
+      "listen": "<p>\"A gentle answer turns away wrath...\"</p><span class=\"verse-ref\">Proverbs 15:1</span>",
+      "think": "<p>Gentleness is not weakness. It is strength governed by wisdom and love. A gentle response can interrupt cycles of tension and make room for peace.</p><p>You cannot control every conversation, but you can surrender your own words to God. Let your speech reflect the character of Christ today.</p>",
+      "pray": "<p>Lord, make my responses gentle, wise, and timely. Guard me from harshness and help me speak in ways that honor You. Amen.</p>",
+      "go_action": "<p>In one difficult conversation today, slow down enough to answer gently.</p>",
+      "verses": "[\"Proverbs:15:1\",\"Galatians:5:22-23\",\"2 Timothy:2:24-25\"]"
+    },
+    {
+      "day_number": 163,
+      "title": "Learning Obedience",
+      "pause": "<p>Do not confuse delayed obedience with harmless hesitation. God honors a willing yes.</p>",
+      "listen": "<p>\"Blessed rather are those who hear the word of God and obey it.\"</p><span class=\"verse-ref\">Luke 11:28</span>",
+      "think": "<p>Obedience is where love becomes visible. It is not about earning favor with God, but about responding to His voice with trust.</p><p>You may not understand every implication of what God is asking, but you can still obey the part He has made clear. A simple yes can open the way for deeper clarity.</p>",
+      "pray": "<p>Father, give me a willing heart. Help me hear Your Word and respond with prompt obedience today. Amen.</p>",
+      "go_action": "<p>Identify one clear instruction from Scripture and practice it intentionally today.</p>",
+      "verses": "[\"Luke:11:28\",\"John:14:23\",\"James:1:22\"]"
+    },
+    {
+      "day_number": 164,
+      "title": "Sheltered Under His Wings",
+      "pause": "<p>If life feels exposed and uncertain, remember that God is a place of refuge.</p>",
+      "listen": "<p>\"He will cover you with his feathers, and under his wings you will find refuge...\"</p><span class=\"verse-ref\">Psalm 91:4</span>",
+      "think": "<p>This picture of God is tender and strong at the same time. His protection is not cold distance, but personal care. He gathers, covers, and keeps.</p><p>You may not feel secure because of what is happening around you, but you can still be secure in the One who watches over you. Rest under His faithful care.</p>",
+      "pray": "<p>Lord, be my refuge today. Cover me with Your peace and help me rest under Your faithful protection. Amen.</p>",
+      "go_action": "<p>Pray Psalm 91:4 over yourself or someone you love today.</p>",
+      "verses": "[\"Psalm:91:4\",\"Psalm:57:1\",\"Ruth:2:12\"]"
+    },
+    {
+      "day_number": 165,
+      "title": "Your Labor Is Not in Vain",
+      "pause": "<p>When effort feels unseen, bring that discouragement to God.</p>",
+      "listen": "<p>\"...your labor in the Lord is not in vain.\"</p><span class=\"verse-ref\">1 Corinthians 15:58</span>",
+      "think": "<p>Faithful work can feel invisible. Service, prayer, parenting, study, and quiet perseverance may not receive immediate recognition. But God sees it all.</p><p>What is done in the Lord carries eternal significance. Do not measure value only by visible results. Continue steadfastly, trusting that none of your faithful labor is wasted in His hands.</p>",
+      "pray": "<p>God, encourage me where I feel unnoticed. Help me remain steadfast and remember that my labor in You is never wasted. Amen.</p>",
+      "go_action": "<p>Keep showing up faithfully in one place where you have felt discouraged to quit.</p>",
+      "verses": "[\"1 Corinthians:15:58\",\"Galatians:6:9\",\"Hebrews:6:10\"]"
+    },
+    {
+      "day_number": 166,
+      "title": "The Lord Will Fight for You",
+      "pause": "<p>Not every battle is yours to control. Some burdens need surrender more than strategy.</p>",
+      "listen": "<p>\"The Lord will fight for you; you need only to be still.\"</p><span class=\"verse-ref\">Exodus 14:14</span>",
+      "think": "<p>Israel stood trapped between the sea and an army. Humanly speaking, there was no way out. But God had not brought them there to abandon them.</p><p>Some situations remind us that salvation belongs to the Lord. Be still does not mean do nothing forever. It means stop living as though everything depends on your own strength.</p>",
+      "pray": "<p>Lord, fight for me where I am powerless. Teach me the stillness of trust and help me surrender what I cannot carry. Amen.</p>",
+      "go_action": "<p>Name one battle you have tried to control and place it deliberately in God's hands today.</p>",
+      "verses": "[\"Exodus:14:14\",\"2 Chronicles:20:17\",\"Psalm:20:7\"]"
+    },
+    {
+      "day_number": 167,
+      "title": "Rooted in Love",
+      "pause": "<p>Let your identity be shaped first by how deeply you are loved by God.</p>",
+      "listen": "<p>\"...being rooted and established in love...\"</p><span class=\"verse-ref\">Ephesians 3:17</span>",
+      "think": "<p>Many insecurities grow where love feels uncertain. But the gospel roots us in the unchanging love of Christ. That love is deeper than fear, failure, or comparison.</p><p>A rooted life becomes more stable and more fruitful. Let yourself be grounded again in the truth that you are loved by God, not because you performed well, but because He is gracious.</p>",
+      "pray": "<p>Jesus, root me more deeply in Your love. Let that love steady my heart and reshape how I see myself and others. Amen.</p>",
+      "go_action": "<p>Read Ephesians 3:17-19 slowly and receive it as truth for your own life.</p>",
+      "verses": "[\"Ephesians:3:17-19\",\"Romans:8:38-39\",\"1 John:4:16\"]"
+    },
+    {
+      "day_number": 168,
+      "title": "A Thankful Spirit",
+      "pause": "<p>Gratitude can refocus the heart even when life is not perfect.</p>",
+      "listen": "<p>\"Give thanks in all circumstances...\"</p><span class=\"verse-ref\">1 Thessalonians 5:18</span>",
+      "think": "<p>Thankfulness does not deny pain or difficulty. It chooses to notice God's goodness within and around them. Gratitude keeps the heart open to grace.</p><p>In every season there are reasons to give thanks, even if they are small. A thankful spirit does not ignore what is hard; it refuses to let hardship become the only thing seen.</p>",
+      "pray": "<p>Father, grow gratitude in me today. Open my eyes to Your goodness and keep complaint from ruling my heart. Amen.</p>",
+      "go_action": "<p>Thank God out loud for five specific things before the day ends.</p>",
+      "verses": "[\"1 Thessalonians:5:18\",\"Psalm:103:2\",\"Colossians:3:15\"]"
+    },
+    {
+      "day_number": 169,
+      "title": "The Discipline of Trust",
+      "pause": "<p>Trust is often learned in repeated moments, not instant breakthroughs.</p>",
+      "listen": "<p>\"Trust in the Lord with all your heart...\"</p><span class=\"verse-ref\">Proverbs 3:5</span>",
+      "think": "<p>Trust grows through practice. It is formed when we choose God's wisdom over our own panic, His promises over our assumptions, and His timing over our urgency.</p><p>The disciplined heart keeps returning to trust even after fear has spoken loudly. Keep leaning toward the Lord. He knows how to direct your path.</p>",
+      "pray": "<p>Lord, teach me to trust You more fully. Where I lean on my own understanding, correct me gently and lead me in Your way. Amen.</p>",
+      "go_action": "<p>Bring one recurring worry to God again today instead of rehearsing it alone.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:12:2\"]"
+    },
+    {
+      "day_number": 170,
+      "title": "Peace with Others",
+      "pause": "<p>Ask God if there is a relationship where He is inviting you to pursue peace.</p>",
+      "listen": "<p>\"If it is possible, as far as it depends on you, live at peace with everyone.\"</p><span class=\"verse-ref\">Romans 12:18</span>",
+      "think": "<p>Peace is not always fully possible because relationships involve more than one heart. But Scripture calls us to do the part that belongs to us with humility and sincerity.</p><p>You may not be responsible for another person's response, but you are responsible for your own posture. Pursue peace where you can, and trust God with what remains unresolved.</p>",
+      "pray": "<p>Father, show me how to pursue peace faithfully. Give me humility, courage, and wisdom in strained relationships. Amen.</p>",
+      "go_action": "<p>Take one peaceful step today, whether through a kind message, an apology, or a refusal to escalate tension.</p>",
+      "verses": "[\"Romans:12:18\",\"Hebrews:12:14\",\"Matthew:5:23-24\"]"
+    },
+    {
+      "day_number": 171,
+      "title": "God Is Near in Trouble",
+      "pause": "<p>You do not need to pretend strength when trouble comes. Bring your need honestly to God.</p>",
+      "listen": "<p>\"The Lord is near to all who call on him...\"</p><span class=\"verse-ref\">Psalm 145:18</span>",
+      "think": "<p>Trouble often makes God feel far, but Scripture says otherwise. He is near to those who call on Him in truth. His nearness is not based on your feelings, but on His faithfulness.</p><p>Call on Him today. Speak plainly. He is not avoiding your pain. He is present within it.</p>",
+      "pray": "<p>Lord, thank You that You are near in trouble. Draw close to me today and help me call on You with honesty and faith. Amen.</p>",
+      "go_action": "<p>Turn one moment of distress today into a simple spoken prayer: \"Lord, be near to me.\"</p>",
+      "verses": "[\"Psalm:145:18\",\"Psalm:34:17\",\"Nahum:1:7\"]"
+    },
+    {
+      "day_number": 172,
+      "title": "A Mind Renewed",
+      "pause": "<p>Offer your thought life to God. Transformation often begins there.</p>",
+      "listen": "<p>\"Be transformed by the renewing of your mind...\"</p><span class=\"verse-ref\">Romans 12:2</span>",
+      "think": "<p>The mind is a place of spiritual formation. Left unattended, it can drift toward fear, pride, resentment, or deception. But the Spirit renews us through truth.</p><p>Pay attention to what is shaping your thinking. Let God's Word correct and re-form the patterns of your mind so your life can follow in renewed ways.</p>",
+      "pray": "<p>God, renew my mind today. Replace falsehood with truth and make my thinking more like the mind of Christ. Amen.</p>",
+      "go_action": "<p>Challenge one recurring negative thought with a verse of truth today.</p>",
+      "verses": "[\"Romans:12:2\",\"Philippians:4:8\",\"Ephesians:4:23\"]"
+    },
+    {
+      "day_number": 173,
+      "title": "Wait for His Direction",
+      "pause": "<p>Rushing can feel productive, but waiting on God can be more fruitful.</p>",
+      "listen": "<p>\"Whether you turn to the right or to the left, your ears will hear a voice behind you...\"</p><span class=\"verse-ref\">Isaiah 30:21</span>",
+      "think": "<p>Guidance is often clearest to the heart that is not insisting on its own pace. God knows how to direct the surrendered soul.</p><p>If you feel uncertain, resist the pressure to force clarity. Wait prayerfully, stay obedient in what is already clear, and trust that God will guide the next step in time.</p>",
+      "pray": "<p>Father, keep me from impatient decisions. Help me wait for Your direction and recognize Your leading clearly. Amen.</p>",
+      "go_action": "<p>Delay one unnecessary rushed decision today so you can pray and discern more carefully.</p>",
+      "verses": "[\"Isaiah:30:21\",\"Psalm:25:4-5\",\"Habakkuk:2:1\"]"
+    },
+    {
+      "day_number": 174,
+      "title": "Carried in Community",
+      "pause": "<p>Remember that God often helps us through the presence of other people.</p>",
+      "listen": "<p>\"Carry each other's burdens...\"</p><span class=\"verse-ref\">Galatians 6:2</span>",
+      "think": "<p>We were not designed to bear every weight alone. Community is one of God's gracious gifts for endurance and healing. Both giving help and receiving help are holy acts.</p><p>If you have been isolating, consider that humility may look like letting someone walk with you. God often strengthens us through shared burdens.</p>",
+      "pray": "<p>Lord, thank You for the gift of community. Teach me to carry others faithfully and to receive help humbly when I need it. Amen.</p>",
+      "go_action": "<p>Reach out to one trusted person today, either to encourage them or to ask for prayer.</p>",
+      "verses": "[\"Galatians:6:2\",\"Ecclesiastes:4:9-10\",\"Romans:12:15\"]"
+    },
+    {
+      "day_number": 175,
+      "title": "Chosen for Good Works",
+      "pause": "<p>Your life is not accidental. God has prepared meaningful work for you to walk in.</p>",
+      "listen": "<p>\"For we are God's handiwork, created in Christ Jesus to do good works...\"</p><span class=\"verse-ref\">Ephesians 2:10</span>",
+      "think": "<p>You are not saved by good works, but you are saved for them. God has shaped your life, gifts, and opportunities with purpose. Even ordinary moments can become settings for prepared obedience.</p><p>Ask not only what you want from the day, but what good work God may have prepared within it. Purpose is often found in simple faithfulness.</p>",
+      "pray": "<p>Father, thank You that my life has purpose in Christ. Open my eyes to the good works You have prepared for me today. Amen.</p>",
+      "go_action": "<p>Look for one practical way to serve someone today as part of your calling in Christ.</p>",
+      "verses": "[\"Ephesians:2:10\",\"Titus:2:14\",\"Matthew:5:16\"]"
+    },
+    {
+      "day_number": 176,
+      "title": "Patience in Process",
+      "pause": "<p>Growth rarely happens instantly. Give God's process room to work.</p>",
+      "listen": "<p>\"Let perseverance finish its work...\"</p><span class=\"verse-ref\">James 1:4</span>",
+      "think": "<p>We often want the finished fruit without the long process of formation. But perseverance has work to do in us. God uses time, pressure, and repetition to mature what is still developing.</p><p>Do not resist the process simply because it is slow. Some of God's deepest work happens over time, not overnight.</p>",
+      "pray": "<p>Lord, give me patience in the process of growth. Help me cooperate with what You are forming in me instead of rushing past it. Amen.</p>",
+      "go_action": "<p>Thank God today for one area where He is shaping you gradually rather than instantly.</p>",
+      "verses": "[\"James:1:4\",\"Romans:5:3-4\",\"Philippians:1:6\"]"
+    },
+    {
+      "day_number": 177,
+      "title": "Joy in His Presence",
+      "pause": "<p>Joy is found not merely in changed circumstances, but in the nearness of God.</p>",
+      "listen": "<p>\"In your presence there is fullness of joy...\"</p><span class=\"verse-ref\">Psalm 16:11</span>",
+      "think": "<p>The deepest joy is relational. It comes from knowing and enjoying God. That joy can exist even in imperfect seasons because its source is not fragile.</p><p>If your heart feels dull, do not only ask for happier conditions. Ask for a deeper awareness of God's presence. Joy grows there.</p>",
+      "pray": "<p>God, draw me into the joy of Your presence today. Lift my eyes to You and renew gladness in my soul. Amen.</p>",
+      "go_action": "<p>Spend a few minutes worshiping God simply for who He is.</p>",
+      "verses": "[\"Psalm:16:11\",\"John:15:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 178,
+      "title": "The Courage to Begin Again",
+      "pause": "<p>If you have stumbled, remember that failure does not have to define the next step.</p>",
+      "listen": "<p>\"Though the righteous fall seven times, they rise again...\"</p><span class=\"verse-ref\">Proverbs 24:16</span>",
+      "think": "<p>The life of faith is not marked by never falling, but by rising again through God's grace. Shame tells you to stay down. Grace calls you to stand up and keep walking with humility.</p><p>Beginning again takes courage, but God supplies that too. Return to Him without delay. There is mercy for the next step.</p>",
+      "pray": "<p>Lord, thank You for mercy that lets me begin again. Lift me out of discouragement and strengthen me to walk forward with renewed faith. Amen.</p>",
+      "go_action": "<p>Take one restoring step today in an area where you have felt like giving up.</p>",
+      "verses": "[\"Proverbs:24:16\",\"Micah:7:8\",\"1 John:1:9\"]"
+    },
+    {
+      "day_number": 179,
+      "title": "Speak What Is True",
+      "pause": "<p>Ask God to align your words with truth, kindness, and courage.</p>",
+      "listen": "<p>\"Therefore each of you must put off falsehood and speak truthfully...\"</p><span class=\"verse-ref\">Ephesians 4:25</span>",
+      "think": "<p>Truthfulness honors God and strengthens trust. Speaking truth does not mean becoming harsh; it means letting honesty be shaped by love and integrity.</p><p>In a world of exaggeration, avoidance, and image management, simple truthfulness shines. Let your words today be dependable and clean.</p>",
+      "pray": "<p>God, make me truthful in word and motive. Help me speak honestly, kindly, and without fear. Amen.</p>",
+      "go_action": "<p>Choose honesty today in one place where it would be easier to be vague or evasive.</p>",
+      "verses": "[\"Ephesians:4:25\",\"Proverbs:12:22\",\"Colossians:3:9-10\"]"
+    },
+    {
+      "day_number": 180,
+      "title": "Open Hands",
+      "pause": "<p>Clenched hands cannot receive well. Open your heart before God again.</p>",
+      "listen": "<p>\"Cast all your anxiety on him because he cares for you.\"</p><span class=\"verse-ref\">1 Peter 5:7</span>",
+      "think": "<p>Surrender is not losing what matters most. It is entrusting what matters most to the God who cares. Anxiety tightens our grip, but grace teaches us to release.</p><p>Open hands are a posture of trust. What you place in God's care is safer there than in your own anxious control.</p>",
+      "pray": "<p>Father, I release my anxieties to You today. Teach me the freedom of open hands and trusting surrender. Amen.</p>",
+      "go_action": "<p>Hold your hands open in prayer for one minute and name what you are releasing to God.</p>",
+      "verses": "[\"1 Peter:5:7\",\"Psalm:55:22\",\"Matthew:6:25-27\"]"
+    },
+    {
+      "day_number": 181,
+      "title": "He Will Complete the Work",
+      "pause": "<p>Look back at how far God has already brought you, then entrust the unfinished parts to Him.</p>",
+      "listen": "<p>\"...he who began a good work in you will carry it on to completion...\"</p><span class=\"verse-ref\">Philippians 1:6</span>",
+      "think": "<p>Your story with God is not abandoned halfway. What He begins, He intends to complete. That does not remove the need for obedience, but it fills obedience with confidence.</p><p>You are still in process, and that is not a failure. It is evidence that God is still at work. Rest in His commitment to finish what He started in you.</p>",
+      "pray": "<p>Lord, thank You for Your faithful work in my life. Keep me hopeful in the unfinished places and steady in daily obedience. Amen.</p>",
+      "go_action": "<p>Reflect on one area where God has already changed you, and thank Him for the work He will continue.</p>",
+      "verses": "[\"Philippians:1:6\",\"1 Thessalonians:5:23-24\",\"Hebrews:10:23\"]"
+    },
+    {
+      "day_number": 182,
+      "title": "Led by the Shepherd",
+      "pause": "<p>Picture Jesus not as distant, but near enough to lead you step by step today.</p>",
+      "listen": "<p>\"The Lord is my shepherd, I lack nothing.\"</p><span class=\"verse-ref\">Psalm 23:1</span>",
+      "think": "<p>A shepherd does not merely point the way from afar. He stays near, guides, protects, and provides. That is how God relates to His people.</p><p>You may not know all that lies ahead, but you do know who leads you. The Shepherd is enough for every path you walk today.</p>",
+      "pray": "<p>Good Shepherd, lead me today. Help me trust Your care, follow Your voice, and rest in Your provision. Amen.</p>",
+      "go_action": "<p>Before your next task, pause and ask the Lord to shepherd your steps through it.</p>",
+      "verses": "[\"Psalm:23:1\",\"John:10:14\",\"Isaiah:40:11\"]"
+    },
+    {
+      "day_number": 183,
+      "title": "Steady in the Storm",
+      "pause": "<p>Bring to mind the situation that feels turbulent, then remember Christ is present there too.</p>",
+      "listen": "<p>\"Then he got up and rebuked the winds and the waves, and it was completely calm.\"</p><span class=\"verse-ref\">Matthew 8:26</span>",
+      "think": "<p>The presence of a storm does not mean the absence of God. Jesus was in the boat with His disciples even when fear told them otherwise.</p><p>Storms reveal where we place our trust. When waves rise, look again to the One who holds authority over what threatens to overwhelm you.</p>",
+      "pray": "<p>Lord Jesus, steady my heart in the storm. Help me trust Your presence and power more than I fear the waves around me. Amen.</p>",
+      "go_action": "<p>In one stressful moment today, whisper, \"Jesus is in this with me.\"</p>",
+      "verses": "[\"Matthew:8:26\",\"Psalm:107:29\",\"Mark:4:39-40\"]"
+    },
+    {
+      "day_number": 184,
+      "title": "Strengthened from Within",
+      "pause": "<p>External pressures are real, but ask God to strengthen the deeper place inside you.</p>",
+      "listen": "<p>\"...that he may strengthen you with power through his Spirit in your inner being...\"</p><span class=\"verse-ref\">Ephesians 3:16</span>",
+      "think": "<p>Not every battle is solved by changing circumstances first. Sometimes God meets us by strengthening the inner life so we can endure, love, and stay faithful.</p><p>Inner strength comes from the Spirit, not from pretending everything is fine. Let God fortify your heart where you are most vulnerable.</p>",
+      "pray": "<p>Father, strengthen me in my inner being by Your Spirit. Make me resilient in faith, patient in love, and steady in hope. Amen.</p>",
+      "go_action": "<p>Pray Ephesians 3:16 over yourself before stepping into a demanding part of your day.</p>",
+      "verses": "[\"Ephesians:3:16\",\"Colossians:1:11\",\"Isaiah:41:10\"]"
+    },
+    {
+      "day_number": 185,
+      "title": "Light for the Path Ahead",
+      "pause": "<p>You may not need the whole journey explained. Ask God for light enough for the next step.</p>",
+      "listen": "<p>\"Your word is a lamp for my feet, a light on my path.\"</p><span class=\"verse-ref\">Psalm 119:105</span>",
+      "think": "<p>God's guidance often comes as enough light for faithful movement, not full visibility of the future. That keeps us dependent on Him rather than on our own sense of control.</p><p>If the future feels unclear, stay close to the light you do have. Obedience to today's revealed step prepares the heart for tomorrow's direction.</p>",
+      "pray": "<p>Lord, let Your Word light my path today. Keep me from wandering in confusion and teach me to walk by the light You provide. Amen.</p>",
+      "go_action": "<p>Read one verse slowly today and ask, \"How should I obey this right now?\"</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 186,
+      "title": "A Heart That Listens",
+      "pause": "<p>Quiet your opinions for a moment and ask God to make you more attentive to His voice.</p>",
+      "listen": "<p>\"Speak, Lord, for your servant is listening.\"</p><span class=\"verse-ref\">1 Samuel 3:9</span>",
+      "think": "<p>Listening is an act of surrender. It says that God is wise, good, and worthy of our full attention. A listening heart is often a teachable heart.</p><p>So much of life is filled with noise, reaction, and assumption. Ask God for the grace to listen before speaking, reacting, or deciding.</p>",
+      "pray": "<p>Speak, Lord. Give me a listening heart today and help me respond with humility and obedience. Amen.</p>",
+      "go_action": "<p>Before one important conversation today, pause and ask God for a listening spirit.</p>",
+      "verses": "[\"1 Samuel:3:9\",\"Ecclesiastes:5:1-2\",\"John:10:27\"]"
+    },
+    {
+      "day_number": 187,
+      "title": "Peace in Waiting Rooms",
+      "pause": "<p>If you are waiting on news, answers, or change, let God meet you in the middle of that uncertainty.</p>",
+      "listen": "<p>\"I wait for the Lord, my whole being waits, and in his word I put my hope.\"</p><span class=\"verse-ref\">Psalm 130:5</span>",
+      "think": "<p>Waiting rooms expose what we cling to. They can become places of fear, impatience, or deeper trust. God is present there too.</p><p>Hope in God's Word steadies us while outcomes remain unknown. You are not waiting alone, and your peace does not need to wait for the answer to arrive.</p>",
+      "pray": "<p>Lord, give me peace while I wait. Keep my heart from spiraling and anchor my hope in Your faithful Word. Amen.</p>",
+      "go_action": "<p>When you feel impatience rising today, turn it into a short prayer of trust.</p>",
+      "verses": "[\"Psalm:130:5\",\"Isaiah:40:31\",\"Romans:8:25\"]"
+    },
+    {
+      "day_number": 188,
+      "title": "Grace for Hard Conversations",
+      "pause": "<p>Bring the conversation you are avoiding into God's presence before you bring it to anyone else.</p>",
+      "listen": "<p>\"Let your conversation be always full of grace, seasoned with salt...\"</p><span class=\"verse-ref\">Colossians 4:6</span>",
+      "think": "<p>Some conversations require courage, but they also require grace. Truth without love can wound, while silence without wisdom can prolong harm.</p><p>Ask God to make your words clear, timely, and kind. Grace does not weaken truth; it helps truth be carried in a Christlike way.</p>",
+      "pray": "<p>Father, prepare my heart and words for difficult conversations. Help me speak truthfully, gently, and with wisdom. Amen.</p>",
+      "go_action": "<p>Pray before sending one message or having one conversation you know may be difficult.</p>",
+      "verses": "[\"Colossians:4:6\",\"Ephesians:4:15\",\"Proverbs:25:11\"]"
+    },
+    {
+      "day_number": 189,
+      "title": "Shelter for the Tired Soul",
+      "pause": "<p>When your soul feels overexposed, let God be the covering you rest beneath.</p>",
+      "listen": "<p>\"Come to me, all you who are weary and burdened, and I will give you rest.\"</p><span class=\"verse-ref\">Matthew 11:28</span>",
+      "think": "<p>Jesus does not shame the weary for being weary. He invites them. Rest begins not with having everything finished, but with coming honestly to Him.</p><p>Your exhaustion is not an interruption to God's care. It is one more place where His gentleness can meet you.</p>",
+      "pray": "<p>Jesus, I come to You with my tired soul. Give me rest deeper than sleep and peace deeper than a lighter schedule. Amen.</p>",
+      "go_action": "<p>Set aside a short quiet pause today to come to Jesus without trying to fix anything first.</p>",
+      "verses": "[\"Matthew:11:28-29\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 190,
+      "title": "The Discipline of Remembering",
+      "pause": "<p>Look back for a moment. Forgetfulness often feeds fear more than facts do.</p>",
+      "listen": "<p>\"Praise the Lord, my soul, and forget not all his benefits...\"</p><span class=\"verse-ref\">Psalm 103:2</span>",
+      "think": "<p>Remembering God's faithfulness is a spiritual discipline. It trains the heart to interpret the present in light of what God has already done.</p><p>When fear speaks loudly, memory can answer it. The God who has helped you before has not changed.</p>",
+      "pray": "<p>Lord, keep me from forgetting Your goodness. Bring to mind Your faithfulness and let remembrance strengthen my trust today. Amen.</p>",
+      "go_action": "<p>Write down one way God has been faithful to you in the past year.</p>",
+      "verses": "[\"Psalm:103:2\",\"Deuteronomy:8:2\",\"1 Samuel:7:12\"]"
+    },
+    {
+      "day_number": 191,
+      "title": "Freedom from Comparison",
+      "pause": "<p>Release the urge to measure your life against someone else's path.</p>",
+      "listen": "<p>\"Each one should test their own actions... without comparing themselves to someone else.\"</p><span class=\"verse-ref\">Galatians 6:4</span>",
+      "think": "<p>Comparison distracts us from gratitude, calling, and peace. It turns our eyes sideways when God is asking us to walk faithfully forward.</p><p>Your life is not late because it looks different. God writes different stories with equal wisdom. Stay faithful to the grace given to you.</p>",
+      "pray": "<p>Father, free me from comparison. Teach me contentment, gratitude, and joy in the path You have given me. Amen.</p>",
+      "go_action": "<p>Notice one comparison thought today and replace it with thanks for God's work in your own life.</p>",
+      "verses": "[\"Galatians:6:4\",\"John:21:22\",\"Psalm:139:14\"]"
+    },
+    {
+      "day_number": 192,
+      "title": "Mercy for the One Who Failed",
+      "pause": "<p>If you are carrying regret, do not hide it from the God who already knows.</p>",
+      "listen": "<p>\"Let us then approach God's throne of grace with confidence...\"</p><span class=\"verse-ref\">Hebrews 4:16</span>",
+      "think": "<p>Failure can tempt us to withdraw from God, but grace calls us closer. The throne you approach is a throne of grace, not humiliation.</p><p>Mercy does not excuse sin, but it does welcome the repentant. Bring your regret into the light and let God meet you there with help.</p>",
+      "pray": "<p>God of grace, I come to You with what I wish I had done differently. Meet me with mercy, cleanse me, and restore my steps. Amen.</p>",
+      "go_action": "<p>Confess one regret honestly to God today and receive His forgiveness instead of rehearsing shame.</p>",
+      "verses": "[\"Hebrews:4:16\",\"Psalm:51:17\",\"1 John:1:9\"]"
+    },
+    {
+      "day_number": 193,
+      "title": "Open Doors in God's Timing",
+      "pause": "<p>Some doors need patience as much as prayer. Trust God's timing with what has not opened yet.</p>",
+      "listen": "<p>\"See, I have placed before you an open door that no one can shut.\"</p><span class=\"verse-ref\">Revelation 3:8</span>",
+      "think": "<p>God knows which doors should open, which should stay closed, and when each should happen. His wisdom is kinder than our impatience.</p><p>When the right door opens, it will be sustained by His providence rather than by panic. Keep walking faithfully until then.</p>",
+      "pray": "<p>Lord, teach me to trust Your timing with open and closed doors. Keep me from forcing what You have not opened and give me courage when You do. Amen.</p>",
+      "go_action": "<p>Surrender one hoped-for opportunity to God today and ask for contentment while you wait.</p>",
+      "verses": "[\"Revelation:3:8\",\"Ecclesiastes:3:11\",\"Psalm:84:11\"]"
+    },
+    {
+      "day_number": 194,
+      "title": "Courage for Hidden Faithfulness",
+      "pause": "<p>Not all obedience is public. Some of the bravest faithfulness happens where few people see it.</p>",
+      "listen": "<p>\"And your Father, who sees what is done in secret, will reward you.\"</p><span class=\"verse-ref\">Matthew 6:6</span>",
+      "think": "<p>God sees the unseen prayers, the private integrity, the quiet refusals to compromise, and the small acts of love no one applauds.</p><p>Hidden faithfulness is never invisible to Him. Let that steady you when recognition is absent and obedience feels costly.</p>",
+      "pray": "<p>Father, strengthen me to be faithful in secret places. Let my integrity and devotion be shaped by Your gaze more than by human attention. Amen.</p>",
+      "go_action": "<p>Do one unseen act of obedience today as worship to God alone.</p>",
+      "verses": "[\"Matthew:6:6\",\"Luke:16:10\",\"Hebrews:4:13\"]"
+    },
+    {
+      "day_number": 195,
+      "title": "Held in Your Weakest Moment",
+      "pause": "<p>If you feel fragile today, do not mistake fragility for abandonment.</p>",
+      "listen": "<p>\"My flesh and my heart may fail, but God is the strength of my heart...\"</p><span class=\"verse-ref\">Psalm 73:26</span>",
+      "think": "<p>There are moments when emotional, physical, or spiritual weakness feels overwhelming. Yet even then, God remains the strength of your heart.</p><p>Your failures in strength do not cancel His steadiness. He knows how to hold what feels like it is slipping.</p>",
+      "pray": "<p>Lord, be the strength of my heart today. Where I feel weak, fragile, or uncertain, hold me with Your faithful care. Amen.</p>",
+      "go_action": "<p>Admit one area of weakness to God plainly today instead of hiding it behind self-reliance.</p>",
+      "verses": "[\"Psalm:73:26\",\"Isaiah:40:29\",\"2 Corinthians:12:10\"]"
+    },
+    {
+      "day_number": 196,
+      "title": "When God Says Rest",
+      "pause": "<p>Some acts of faith look like movement. Others look like obedient rest.</p>",
+      "listen": "<p>\"In repentance and rest is your salvation, in quietness and trust is your strength...\"</p><span class=\"verse-ref\">Isaiah 30:15</span>",
+      "think": "<p>We can become so used to striving that rest feels irresponsible. Yet Scripture teaches that quiet trust can be a form of strength, not weakness.</p><p>Rest is not laziness when it is received from God. It is a refusal to live as though everything depends on your endless effort.</p>",
+      "pray": "<p>Father, teach me when to work and when to rest. Help me receive quietness and trust as gifts from You rather than resist them. Amen.</p>",
+      "go_action": "<p>Honor one boundary of rest today without guilt, offering that space back to God.</p>",
+      "verses": "[\"Isaiah:30:15\",\"Psalm:127:2\",\"Mark:2:27\"]"
+    },
+    {
+      "day_number": 197,
+      "title": "Guard the Wellspring",
+      "pause": "<p>Pay attention to the inner life today. What fills the heart eventually shapes the whole life.</p>",
+      "listen": "<p>\"Above all else, guard your heart, for everything you do flows from it.\"</p><span class=\"verse-ref\">Proverbs 4:23</span>",
+      "think": "<p>The heart is a wellspring. What is nurtured there will eventually surface in words, desires, attitudes, and choices. That is why guarding the heart matters so deeply.</p><p>Be attentive to what you are absorbing and rehearsing. Invite God to keep your inner life clear, soft, and aligned with truth.</p>",
+      "pray": "<p>Lord, guard my heart today. Keep me from what hardens, deceives, or distracts me, and form in me what is pure and life-giving. Amen.</p>",
+      "go_action": "<p>Remove one input today that has been feeding anxiety, distraction, or compromise in your heart.</p>",
+      "verses": "[\"Proverbs:4:23\",\"Philippians:4:8\",\"Psalm:51:10\"]"
+    },
+    {
+      "day_number": 198,
+      "title": "Joy That Outlasts Circumstances",
+      "pause": "<p>Bring your shifting emotions before God, and ask Him for a joy rooted deeper than the moment.</p>",
+      "listen": "<p>\"Though you have not seen him, you love him... and are filled with an inexpressible and glorious joy...\"</p><span class=\"verse-ref\">1 Peter 1:8</span>",
+      "think": "<p>Christian joy is not the denial of grief or difficulty. It is a deep gladness in Christ that can live alongside pain because its source is higher than circumstance.</p><p>When the heart is anchored in Jesus, joy may dim at times, but it is not destroyed by every changing situation. Ask God to renew that deeper joy in you today.</p>",
+      "pray": "<p>Jesus, renew a deeper joy in me. Let my heart find gladness in who You are, even when circumstances feel unsettled. Amen.</p>",
+      "go_action": "<p>Thank God for one truth about Christ today, not just for one improved circumstance.</p>",
+      "verses": "[\"1 Peter:1:8\",\"Habakkuk:3:17-18\",\"John:16:22\"]"
+    },
+    {
+      "day_number": 199,
+      "title": "Wisdom for Your Words",
+      "pause": "<p>Speech shapes relationships, so invite God into your mouth before the day unfolds.</p>",
+      "listen": "<p>\"Set a guard over my mouth, Lord; keep watch over the door of my lips.\"</p><span class=\"verse-ref\">Psalm 141:3</span>",
+      "think": "<p>Some of the day's greatest opportunities and greatest regrets can come through words. We need wisdom not just in what we say, but in when, why, and how we say it.</p><p>God can teach your speech to become cleaner, gentler, and more useful. Offer Him your words before they are spoken.</p>",
+      "pray": "<p>Lord, guard my mouth today. Let my words be honest, wise, and full of grace, and keep me from speech that harms. Amen.</p>",
+      "go_action": "<p>Pause before one important response today and ask, \"Will these words give life?\"</p>",
+      "verses": "[\"Psalm:141:3\",\"Proverbs:15:23\",\"Ephesians:4:29\"]"
+    },
+    {
+      "day_number": 200,
+      "title": "A Song in Ordinary Days",
+      "pause": "<p>Worship is not only for milestone moments. God is worthy in the quiet middle of life too.</p>",
+      "listen": "<p>\"...singing and making music from your heart to the Lord...\"</p><span class=\"verse-ref\">Ephesians 5:19</span>",
+      "think": "<p>Ordinary days can feel spiritually flat if we only expect God to meet us in dramatic moments. Yet worship awakens the heart to His constant worth and presence.</p><p>You do not need a perfect mood to worship. Sometimes praise is the very thing that reorients the soul on an average day.</p>",
+      "pray": "<p>Father, put a song in my heart today. Teach me to worship You not only in big moments, but in the ordinary rhythm of daily life. Amen.</p>",
+      "go_action": "<p>Sing or play one worship song today during a routine part of your schedule.</p>",
+      "verses": "[\"Ephesians:5:19-20\",\"Psalm:96:1\",\"Acts:16:25\"]"
+    },
+    {
+      "day_number": 201,
+      "title": "Firm on the Foundation",
+      "pause": "<p>Consider what your confidence is resting on today. Only one foundation truly holds.</p>",
+      "listen": "<p>\"For no one can lay any foundation other than the one already laid, which is Jesus Christ.\"</p><span class=\"verse-ref\">1 Corinthians 3:11</span>",
+      "think": "<p>Many things can seem sturdy until pressure comes. Reputation, ability, money, and approval are unstable foundations for the soul. Christ alone can bear the full weight of your life.</p><p>When the foundation is secure, storms may still shake the house, but they do not have the final word. Build again today on what will last.</p>",
+      "pray": "<p>Jesus, keep my life grounded in You. Expose every false foundation and strengthen what is built on Your truth. Amen.</p>",
+      "go_action": "<p>Ask yourself honestly today, \"What have I been leaning on more than Christ?\" and surrender it to Him.</p>",
+      "verses": "[\"1 Corinthians:3:11\",\"Matthew:7:24-25\",\"Psalm:18:2\"]"
+    },
+    {
+      "day_number": 202,
+      "title": "Compassion That Moves Toward Others",
+      "pause": "<p>Ask God to interrupt self-focus and make you attentive to the needs around you.</p>",
+      "listen": "<p>\"Be kind and compassionate to one another...\"</p><span class=\"verse-ref\">Ephesians 4:32</span>",
+      "think": "<p>Compassion is more than feeling sorry from a distance. It moves toward people with mercy, patience, and practical care. The heart of Christ is never indifferent to human need.</p><p>Kindness may seem small, but in God's hands it becomes a tangible expression of His love. Let compassion shape how you notice and respond today.</p>",
+      "pray": "<p>Father, make me compassionate today. Help me notice people well and respond with the kindness of Christ. Amen.</p>",
+      "go_action": "<p>Take one practical step of kindness toward someone today, even if it seems small.</p>",
+      "verses": "[\"Ephesians:4:32\",\"Luke:10:33-34\",\"Colossians:3:12\"]"
+    },
+    {
+      "day_number": 203,
+      "title": "Hope for the Heavy Heart",
+      "pause": "<p>If heaviness has settled over you, bring it honestly into the presence of God.</p>",
+      "listen": "<p>\"Why, my soul, are you downcast? ... Put your hope in God...\"</p><span class=\"verse-ref\">Psalm 42:11</span>",
+      "think": "<p>Scripture makes room for the downcast soul. It does not ignore heaviness, but it does teach us to speak hope into it. Hope is not denial. It is a decision to remember where help comes from.</p><p>You may need to keep returning your soul to this truth today: God is still worthy of hope, even in the middle of inner heaviness.</p>",
+      "pray": "<p>Lord, lift my heavy heart and help me put my hope in You again. Meet me gently where my spirit feels low. Amen.</p>",
+      "go_action": "<p>Speak Psalm 42:11 aloud today as a prayer when heaviness rises.</p>",
+      "verses": "[\"Psalm:42:11\",\"Psalm:34:18\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 204,
+      "title": "Guided into Truth",
+      "pause": "<p>Invite the Spirit to guide you where confusion or distortion has made things blurry.</p>",
+      "listen": "<p>\"...the Spirit of truth... will guide you into all the truth...\"</p><span class=\"verse-ref\">John 16:13</span>",
+      "think": "<p>Truth is not merely gathered by effort; it is also received through the Spirit's guidance. He leads believers into clearer understanding of Christ, Scripture, and faithful living.</p><p>Where you feel confused, ask God not just for information but for illumination. He delights to guide His people in truth.</p>",
+      "pray": "<p>Holy Spirit, guide me into truth today. Clear away confusion and help me discern what is right, faithful, and pleasing to God. Amen.</p>",
+      "go_action": "<p>Bring one area of confusion to God in prayer and ask specifically for truth and discernment.</p>",
+      "verses": "[\"John:16:13\",\"Psalm:25:5\",\"1 John:2:27\"]"
+    },
+    {
+      "day_number": 205,
+      "title": "Faith That Keeps Showing Up",
+      "pause": "<p>Not all faith looks dramatic. Much of it looks like steady presence and continued obedience.</p>",
+      "listen": "<p>\"Let us not become weary in doing good...\"</p><span class=\"verse-ref\">Galatians 6:9</span>",
+      "think": "<p>Some seasons require endurance more than excitement. Faith keeps showing up, keeps praying, keeps loving, and keeps obeying even when results unfold slowly.</p><p>Steady faithfulness matters to God. Do not underestimate the spiritual beauty of refusing to quit in the place He has called you.</p>",
+      "pray": "<p>Lord, strengthen me to keep showing up in faith. Guard me from weariness that leads to surrender, and help me persevere in doing good. Amen.</p>",
+      "go_action": "<p>Return faithfully today to one responsibility or calling you have been tempted to abandon.</p>",
+      "verses": "[\"Galatians:6:9\",\"Hebrews:10:36\",\"Revelation:2:10\"]"
+    },
+    {
+      "day_number": 206,
+      "title": "The Kindness of Correction",
+      "pause": "<p>Correction can feel uncomfortable, but ask God to help you receive truth as kindness.</p>",
+      "listen": "<p>\"Whoever heeds life-giving correction will be at home among the wise.\"</p><span class=\"verse-ref\">Proverbs 15:31</span>",
+      "think": "<p>Correction is not always rejection. In God's hands, it becomes a means of growth, protection, and wisdom. The proud heart resists correction; the humble heart learns from it.</p><p>Where God exposes something in you, He is not trying to shame you but to form you. Receive His loving correction and let it make room for greater maturity.</p>",
+      "pray": "<p>Father, make me teachable. Help me receive correction without defensiveness and respond with humility and growth. Amen.</p>",
+      "go_action": "<p>Reflect on one recent correction or conviction and ask God what good fruit He wants to bring from it.</p>",
+      "verses": "[\"Proverbs:15:31\",\"Hebrews:12:11\",\"Psalm:141:5\"]"
+    },
+    {
+      "day_number": 207,
+      "title": "Confidence to Approach God",
+      "pause": "<p>You do not need to approach God timidly as though you are barely tolerated.</p>",
+      "listen": "<p>\"In him and through faith in him we may approach God with freedom and confidence.\"</p><span class=\"verse-ref\">Ephesians 3:12</span>",
+      "think": "<p>Because of Christ, you are welcomed into the presence of God. Confidence before Him is not arrogance; it is trust in what Jesus has secured.</p><p>Come freely with your needs, worship, gratitude, and questions. The Father is not reluctant to receive those who come through the Son.</p>",
+      "pray": "<p>Father, thank You that through Christ I may approach You with freedom and confidence. Teach me to pray boldly and rest in Your welcome. Amen.</p>",
+      "go_action": "<p>Bring one need to God today with fresh confidence instead of hesitant distance.</p>",
+      "verses": "[\"Ephesians:3:12\",\"Hebrews:10:19-22\",\"Romans:8:15\"]"
+    },
+    {
+      "day_number": 208,
+      "title": "The Beauty of a Soft Answer",
+      "pause": "<p>Harshness may feel powerful for a moment, but gentleness often carries greater strength.</p>",
+      "listen": "<p>\"A gentle tongue can break a bone.\"</p><span class=\"verse-ref\">Proverbs 25:15</span>",
+      "think": "<p>Softness guided by wisdom can accomplish what force cannot. Gentle speech can disarm defensiveness and make space for truth to be heard.</p><p>This does not mean silence in the face of wrong. It means learning the Christlike strength of self-controlled, gracious communication.</p>",
+      "pray": "<p>Lord, shape my tone as much as my content. Make my speech gentle, strong, and wise in every interaction today. Amen.</p>",
+      "go_action": "<p>Choose one moment today to answer softly where irritation would normally take over.</p>",
+      "verses": "[\"Proverbs:25:15\",\"Proverbs:15:1\",\"James:3:17\"]"
+    },
+    {
+      "day_number": 209,
+      "title": "Daily Bread, Daily Trust",
+      "pause": "<p>Receive today as a day God intends to sustain, not a day you must survive alone.</p>",
+      "listen": "<p>\"Give us today our daily bread.\"</p><span class=\"verse-ref\">Matthew 6:11</span>",
+      "think": "<p>Jesus taught us to ask for daily bread, not because our needs are small, but because trust is learned one day at a time. Dependence is meant to be ongoing, not occasional.</p><p>God knows what is needed today. Ask Him simply, and let that simple dependence reshape your heart away from self-sufficiency.</p>",
+      "pray": "<p>Father, provide what I need for today. Teach me the humility and peace of daily trust in Your care. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him in advance for His care.</p>",
+      "verses": "[\"Matthew:6:11\",\"Proverbs:30:8\",\"Exodus:16:4\"]"
+    },
+    {
+      "day_number": 210,
+      "title": "Blessing the Work of Your Hands",
+      "pause": "<p>Offer your work to God before you measure it by speed, visibility, or praise.</p>",
+      "listen": "<p>\"May the favor of the Lord our God rest on us; establish the work of our hands...\"</p><span class=\"verse-ref\">Psalm 90:17</span>",
+      "think": "<p>Work becomes weighty when it is carried only for human recognition. But when offered to God, even routine labor can become meaningful and blessed.</p><p>Ask not merely for success, but for God's favor, integrity, and lasting usefulness in what you do. He knows how to establish faithful work.</p>",
+      "pray": "<p>Lord, rest Your favor on the work of my hands today. Let what I do be marked by faithfulness, usefulness, and Your blessing. Amen.</p>",
+      "go_action": "<p>Begin one work task today with a short prayer asking God to establish it for His purposes.</p>",
+      "verses": "[\"Psalm:90:17\",\"Colossians:3:23-24\",\"Proverbs:16:3\"]"
+    },
+    {
+      "day_number": 211,
+      "title": "Resting in God's Unchanging Love",
+      "pause": "<p>At the end of this next stretch, settle again into what has never shifted: the love of God for you in Christ.</p>",
+      "listen": "<p>\"Give thanks to the Lord, for he is good. His love endures forever.\"</p><span class=\"verse-ref\">Psalm 136:1</span>",
+      "think": "<p>So much in life changes quickly, but God's love does not. It is not moody, temporary, or fragile. It endures. That means you can rest in it on the brightest days and the hardest ones alike.</p><p>Let the constancy of God's love quiet the fear that everything must be held together by your own effort. You are held by everlasting love.</p>",
+      "pray": "<p>Father, thank You for Your enduring love. Teach me to rest more deeply in what does not change and to live from that secure place. Amen.</p>",
+      "go_action": "<p>End the day by thanking God specifically for ways His love has remained steady in your life.</p>",
+      "verses": "[\"Psalm:136:1\",\"Jeremiah:31:3\",\"Romans:8:38-39\"]"
+    },
+    {
+      "day_number": 212,
+      "title": "Trust in a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 213,
+      "title": "Rest for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 214,
+      "title": "Courage for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 215,
+      "title": "Mercy for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 216,
+      "title": "Light for a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 217,
+      "title": "Love in a Heavy Heart",
+      "pause": "<p>Pause for a moment. Bring the heaviness you may be carrying before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>God is not impatient with the burdened heart. He draws near in compassion and steadies those who feel weighed down.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my heavy heart. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Speak honestly to God about what feels heavy instead of hiding it as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 218,
+      "title": "Hope for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 219,
+      "title": "Peace in Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 220,
+      "title": "Strength for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 221,
+      "title": "Wisdom for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 222,
+      "title": "Grace in Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 223,
+      "title": "Joy for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 224,
+      "title": "Trust in Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 225,
+      "title": "Rest for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 226,
+      "title": "Courage for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 227,
+      "title": "Mercy for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 228,
+      "title": "Light for Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 229,
+      "title": "Love in Slow Growth",
+      "pause": "<p>Pause for a moment. Bring areas where progress feels slower than you hoped before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Growth in God is often gradual. What feels slow to you may still be faithful, deep, and very real.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the slow work You are doing in me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Thank God for one area of growth that has come over time as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 230,
+      "title": "Hope for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 231,
+      "title": "Peace in Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 232,
+      "title": "Strength for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 233,
+      "title": "Wisdom for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 234,
+      "title": "Grace in Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 235,
+      "title": "Joy for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 236,
+      "title": "Trust in Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 237,
+      "title": "Rest for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 238,
+      "title": "Courage for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 239,
+      "title": "Mercy for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 240,
+      "title": "Light for Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 241,
+      "title": "Love in Fragile Faith",
+      "pause": "<p>Pause for a moment. Bring the places where your faith feels small before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Even fragile faith matters when it is placed in a faithful God. He is able to strengthen what feels weak.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my fragile faith. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray honestly, \"Lord, strengthen my faith today\" as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 242,
+      "title": "Hope for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 243,
+      "title": "Peace in Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 244,
+      "title": "Strength for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 245,
+      "title": "Wisdom for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 246,
+      "title": "Grace in Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 247,
+      "title": "Joy for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 248,
+      "title": "Trust in Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 249,
+      "title": "Rest for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 250,
+      "title": "Courage for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 251,
+      "title": "Mercy for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 252,
+      "title": "Light for Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 253,
+      "title": "Love in Open Doors",
+      "pause": "<p>Pause for a moment. Bring the opportunities in front of you before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Not every opportunity is yours to force, but every open door worth walking through can be entrusted to God's timing.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the doors before me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Entrust one opportunity to God's timing instead of forcing it as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 254,
+      "title": "Hope for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 255,
+      "title": "Peace in Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 256,
+      "title": "Strength for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 257,
+      "title": "Wisdom for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 258,
+      "title": "Grace in Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 259,
+      "title": "Joy for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 260,
+      "title": "Trust in Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 261,
+      "title": "Rest for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 262,
+      "title": "Courage for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 263,
+      "title": "Mercy for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 264,
+      "title": "Light for Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 265,
+      "title": "Love in Hard Conversations",
+      "pause": "<p>Pause for a moment. Bring the words you need to speak with wisdom before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Truth is best carried with grace. God can shape both your courage and your tone.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my conversations today. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Pray before one difficult conversation or message today as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 266,
+      "title": "Hope for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 267,
+      "title": "Peace in Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 268,
+      "title": "Strength for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 269,
+      "title": "Wisdom for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 270,
+      "title": "Grace in Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 271,
+      "title": "Joy for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 272,
+      "title": "Trust in Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 273,
+      "title": "Rest for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 274,
+      "title": "Courage for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 275,
+      "title": "Mercy for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 276,
+      "title": "Light for Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 277,
+      "title": "Love in Night Watches",
+      "pause": "<p>Pause for a moment. Bring the concerns that feel louder in quiet hours before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>God is as present in the night as He is in the day. Darkness does not hide you from His care.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the burdens that trouble me at night. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>End the day by giving one nighttime worry to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 278,
+      "title": "Hope for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 279,
+      "title": "Peace in Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 280,
+      "title": "Strength for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 281,
+      "title": "Wisdom for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 282,
+      "title": "Grace in Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 283,
+      "title": "Joy for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 284,
+      "title": "Trust in Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 285,
+      "title": "Rest for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 286,
+      "title": "Mercy for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 287,
+      "title": "Light for Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 288,
+      "title": "Love in Hidden Faithfulness",
+      "pause": "<p>Pause for a moment. Bring the parts of obedience that no one else notices before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>The Father sees what is done in secret. Hidden faithfulness is never invisible to Him.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the hidden places of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one unseen act of faithfulness today as worship to God as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 289,
+      "title": "Hope for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 290,
+      "title": "Peace in New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 291,
+      "title": "Strength for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 292,
+      "title": "Wisdom for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 293,
+      "title": "Grace in New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 294,
+      "title": "Joy for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 295,
+      "title": "Trust in New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 296,
+      "title": "Rest for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 297,
+      "title": "Courage for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 298,
+      "title": "Mercy for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 299,
+      "title": "Light for New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 300,
+      "title": "Love in New Mercies",
+      "pause": "<p>Pause for a moment. Bring your need for a fresh beginning before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>God does not tire of meeting repentant hearts with mercy. His compassion is ready for the day ahead.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my need for fresh mercy. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Receive God's mercy today instead of replaying old shame as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 301,
+      "title": "Hope for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 302,
+      "title": "Peace in the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 303,
+      "title": "Strength for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 304,
+      "title": "Wisdom for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 305,
+      "title": "Grace in the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 306,
+      "title": "Joy for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 307,
+      "title": "Trust in the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 308,
+      "title": "Rest for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 309,
+      "title": "Courage for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 310,
+      "title": "Mercy for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 311,
+      "title": "Light for the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 312,
+      "title": "Love in the Common Day",
+      "pause": "<p>Pause for a moment. Bring this ordinary day before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Ordinary days are still filled with opportunities to walk with God. Much of spiritual maturity is formed in common moments.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in this ordinary day. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Practice one ordinary task today with unusual gratitude as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 313,
+      "title": "Hope for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 314,
+      "title": "Peace in Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 315,
+      "title": "Strength for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 316,
+      "title": "Wisdom for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 317,
+      "title": "Grace in Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 318,
+      "title": "Joy for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 319,
+      "title": "Trust in Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 320,
+      "title": "Rest for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 321,
+      "title": "Courage for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 322,
+      "title": "Mercy for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 323,
+      "title": "Light for Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 324,
+      "title": "Love in Troubled Waters",
+      "pause": "<p>Pause for a moment. Bring the stormy parts of your circumstances before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Storms reveal where hope is anchored. Christ remains Lord over what feels turbulent and loud.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the storms around me. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>In one stressful moment, remind yourself that Christ is with you as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 325,
+      "title": "Hope for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 326,
+      "title": "Peace in the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 327,
+      "title": "Strength for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 328,
+      "title": "Wisdom for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 329,
+      "title": "Grace in the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 330,
+      "title": "Joy for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 331,
+      "title": "Trust in the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 332,
+      "title": "Rest for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 333,
+      "title": "Courage for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 334,
+      "title": "Mercy for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 335,
+      "title": "Light for the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 336,
+      "title": "Love in the Weary Soul",
+      "pause": "<p>Pause for a moment. Bring the tired places in body and soul before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Weariness is not failure. It is one more place where Jesus invites you to come and receive His rest.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in my weary soul. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Take a short pause today simply to rest in God's presence as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 337,
+      "title": "Hope for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 338,
+      "title": "Peace in Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 339,
+      "title": "Strength for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 340,
+      "title": "Wisdom for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 341,
+      "title": "Grace in Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 342,
+      "title": "Joy for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 343,
+      "title": "Trust in Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 344,
+      "title": "Rest for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 345,
+      "title": "Courage for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 346,
+      "title": "Mercy for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 347,
+      "title": "Light for Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 348,
+      "title": "Love in Simple Obedience",
+      "pause": "<p>Pause for a moment. Bring the simple thing God has already made clear before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>Sometimes the clearest spiritual progress comes not from complexity, but from a simple yes to what God has already shown you.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in simple obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Do one clear act of obedience without delaying it as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 349,
+      "title": "Hope for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 350,
+      "title": "Peace in the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 351,
+      "title": "Strength for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 352,
+      "title": "Wisdom for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 353,
+      "title": "Grace in the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    },
+    {
+      "day_number": 354,
+      "title": "Joy for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His joy meet you here.</p>",
+      "listen": "<p>The joy of the Lord strengthens weary hearts and lifts the soul toward Him.</p><span class='verse-ref'>Nehemiah 8:10</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Joy in God runs deeper than changing moods. It grows where the heart stays rooted in His goodness and presence.</p>",
+      "pray": "<p>Lord, meet me with joy in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Nehemiah:8:10\",\"Psalm:16:11\",\"Romans:15:13\"]"
+    },
+    {
+      "day_number": 355,
+      "title": "Trust in the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His trust meet you here.</p>",
+      "listen": "<p>The Lord calls you to trust Him with all your heart and not lean only on yourself.</p><span class='verse-ref'>Proverbs 3:5-6</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Trust often grows in repeated surrender. It is the quiet decision to lean on God's wisdom more than your own understanding.</p>",
+      "pray": "<p>Lord, meet me with trust in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Proverbs:3:5-6\",\"Psalm:37:5\",\"Isaiah:26:4\"]"
+    },
+    {
+      "day_number": 356,
+      "title": "Rest for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His rest meet you here.</p>",
+      "listen": "<p>Jesus invites the weary to come to Him and receive rest for their souls.</p><span class='verse-ref'>Matthew 11:28</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>True rest is more than a lighter schedule. It is the deep relief of bringing your whole self into the care of Christ.</p>",
+      "pray": "<p>Lord, meet me with rest in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Matthew:11:28\",\"Psalm:62:1\",\"Jeremiah:6:16\"]"
+    },
+    {
+      "day_number": 357,
+      "title": "Courage for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His courage meet you here.</p>",
+      "listen": "<p>God's presence makes courageous obedience possible even when the path feels costly.</p><span class='verse-ref'>Joshua 1:9</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>Biblical courage is not the absence of fear. It is moving forward in faith because God is with you.</p>",
+      "pray": "<p>Lord, meet me with courage in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Joshua:1:9\",\"Deuteronomy:31:8\",\"Acts:4:29\"]"
+    },
+    {
+      "day_number": 358,
+      "title": "Mercy for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His mercy meet you here.</p>",
+      "listen": "<p>God's mercy is fresh today and meets you before shame has the final word.</p><span class='verse-ref'>Lamentations 3:22-23</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>The mercy of God renews what guilt and weariness try to drain. He welcomes you again and again with compassion.</p>",
+      "pray": "<p>Lord, meet me with mercy in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Lamentations:3:22-23\",\"Psalm:103:8\",\"Titus:3:5\"]"
+    },
+    {
+      "day_number": 359,
+      "title": "Light for the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His light meet you here.</p>",
+      "listen": "<p>God's Word gives light for the path and clarity for the next faithful step.</p><span class='verse-ref'>Psalm 119:105</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>You do not always need the whole road mapped out. God often gives enough light for obedience one step at a time.</p>",
+      "pray": "<p>Lord, meet me with light in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Psalm:119:105\",\"Proverbs:6:23\",\"2 Peter:1:19\"]"
+    },
+    {
+      "day_number": 360,
+      "title": "Love in the Narrow Path",
+      "pause": "<p>Pause for a moment. Bring the path of obedience, even if it feels costly before God and let His love meet you here.</p>",
+      "listen": "<p>The love of God remains steady, strong, and unshaken by changing circumstances.</p><span class='verse-ref'>Romans 8:38-39</span>",
+      "think": "<p>The faithful path is not always the easiest one, but it is always the path where God's presence goes with you.</p><p>God's love is not fragile or temporary. It is a secure place to stand when the soul feels uncertain.</p>",
+      "pray": "<p>Lord, meet me with love in the path of obedience. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Choose the faithful option in one place where compromise feels easier as an act of trust in God.</p>",
+      "verses": "[\"Romans:8:38-39\",\"1 John:4:16\",\"Jeremiah:31:3\"]"
+    },
+    {
+      "day_number": 361,
+      "title": "Hope for Every Need",
+      "pause": "<p>Pause for a moment. Bring the needs you are aware of right now before God and let His hope meet you here.</p>",
+      "listen": "<p>Scripture reminds you that God fills those who trust Him with living hope.</p><span class='verse-ref'>Romans 15:13</span>",
+      "think": "<p>God is not limited by what concerns you today. He is attentive to the details that feel large and the ones that feel small.</p><p>Hope in God is not fragile optimism. It is steady confidence rooted in His character, promises, and faithful presence.</p>",
+      "pray": "<p>Lord, meet me with hope in every need I carry. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him for His care as an act of trust in God.</p>",
+      "verses": "[\"Romans:15:13\",\"Hebrews:6:19\",\"Psalm:62:5-6\"]"
+    },
+    {
+      "day_number": 362,
+      "title": "Peace in Every Need",
+      "pause": "<p>Pause for a moment. Bring the needs you are aware of right now before God and let His peace meet you here.</p>",
+      "listen": "<p>The Lord gives a peace that steadies the heart beyond what circumstances can explain.</p><span class='verse-ref'>John 14:27</span>",
+      "think": "<p>God is not limited by what concerns you today. He is attentive to the details that feel large and the ones that feel small.</p><p>God often meets anxious hearts not by removing every question at once, but by giving peace strong enough to hold them while they wait.</p>",
+      "pray": "<p>Lord, meet me with peace in every need I carry. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him for His care as an act of trust in God.</p>",
+      "verses": "[\"John:14:27\",\"Isaiah:26:3\",\"Philippians:4:7\"]"
+    },
+    {
+      "day_number": 363,
+      "title": "Strength for Every Need",
+      "pause": "<p>Pause for a moment. Bring the needs you are aware of right now before God and let His strength meet you here.</p>",
+      "listen": "<p>God gives strength to the weary and meets weakness with His sustaining power.</p><span class='verse-ref'>Isaiah 40:29</span>",
+      "think": "<p>God is not limited by what concerns you today. He is attentive to the details that feel large and the ones that feel small.</p><p>Weakness does not disqualify you from God's help. It is often the very place where His strength becomes most visible.</p>",
+      "pray": "<p>Lord, meet me with strength in every need I carry. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him for His care as an act of trust in God.</p>",
+      "verses": "[\"Isaiah:40:29\",\"2 Corinthians:12:9\",\"Psalm:73:26\"]"
+    },
+    {
+      "day_number": 364,
+      "title": "Wisdom for Every Need",
+      "pause": "<p>Pause for a moment. Bring the needs you are aware of right now before God and let His wisdom meet you here.</p>",
+      "listen": "<p>God gladly gives wisdom to those who ask Him with trusting hearts.</p><span class='verse-ref'>James 1:5</span>",
+      "think": "<p>God is not limited by what concerns you today. He is attentive to the details that feel large and the ones that feel small.</p><p>Wisdom is more than information. It is the grace to see clearly, choose faithfully, and walk humbly in the fear of the Lord.</p>",
+      "pray": "<p>Lord, meet me with wisdom in every need I carry. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him for His care as an act of trust in God.</p>",
+      "verses": "[\"James:1:5\",\"Proverbs:3:5-6\",\"Colossians:1:9\"]"
+    },
+    {
+      "day_number": 365,
+      "title": "Grace in Every Need",
+      "pause": "<p>Pause for a moment. Bring the needs you are aware of right now before God and let His grace meet you here.</p>",
+      "listen": "<p>The grace of Christ is sufficient for what you face today.</p><span class='verse-ref'>2 Corinthians 12:9</span>",
+      "think": "<p>God is not limited by what concerns you today. He is attentive to the details that feel large and the ones that feel small.</p><p>Grace is not only pardon for the past. It is present help for today's burdens, temptations, and responsibilities.</p>",
+      "pray": "<p>Lord, meet me with grace in every need I carry. Help me trust You, walk closely with You, and reflect Your goodness today. Amen.</p>",
+      "go_action": "<p>Ask God specifically for today's needs, then thank Him for His care as an act of trust in God.</p>",
+      "verses": "[\"2 Corinthians:12:9\",\"Hebrews:4:16\",\"Romans:5:2\"]"
+    }
+  ]
 }


### PR DESCRIPTION
Replace Electron/Setups/Setup/StoreDB/devotionals-data.json with a significantly expanded devotional dataset. The file was enlarged (approx. 615 -> 3655 lines) to add many new daily devotionals and richer content for the in-app StoreDB, updating the devotional library available to users.