### PR TITLE
Add Leviticus commentary generators and restructure Sermons section

### DIFF
--- a/FrontEndApp/src/App.vue
+++ b/FrontEndApp/src/App.vue
@@ -19,7 +19,7 @@ import { useNavBadgesStore } from './store/navBadgesStore';
 import { onBeforeMount, onBeforeUnmount, onMounted, ref, watch, h } from 'vue';
 import { useThemeStore } from './store/theme';
 import TitleBar from './components/TitleBar/TitleBar.vue';
-import Sermons from './Views/Sermons/Sermons.vue';
+import Grow from './Views/Grow/Grow.vue';
 import SESSION from './util/session';
 import FooterComponent from './components/Footer/Footer.vue';
 import { useMainStore } from './store/main';
@@ -193,10 +193,10 @@ onBeforeUnmount(() => {
                                         menuStore.menuSelected == 'read-bible'
                                     "
                                 />
-                                <Sermons
+                                <Grow
                                     v-show="
                                         menuStore.isRouter == false &&
-                                        menuStore.menuSelected == 'sermons'
+                                        menuStore.menuSelected == 'grow'
                                     "
                                 />
                                 <div class="h-[100%]" v-show="menuStore.isRouter == true">

--- a/FrontEndApp/src/Views/CreateSermon/CreateSermon.vue
+++ b/FrontEndApp/src/Views/CreateSermon/CreateSermon.vue
@@ -221,7 +221,8 @@ function populateForm(sermon: import('../../store/Sermons').SermonType) {
 
 async function goBackToSermons() {
     if (isEditing.value) sermonStore.requestedTab = 'mine';
-    menuStore.setMenuWithNoRoute('sermons');
+    menuStore.growInitialScreen = 'sermons';
+    menuStore.setMenuWithNoRoute('grow');
 
     if (route.name === 'CreateSermon') {
         await router.replace('/');

--- a/FrontEndApp/src/Views/CreateSermon/TextBaseSermon.vue
+++ b/FrontEndApp/src/Views/CreateSermon/TextBaseSermon.vue
@@ -111,11 +111,16 @@ function resetForm() {
     loading.value = false;
     isPublished.value = false;
 }
+
+function closeToSermons() {
+    menuStore.growInitialScreen = 'sermons';
+    menuStore.setMenu('grow');
+}
 </script>
 <template>
     <div class="h-[100%] w-[100%] relative">
         <div class="absolute top-5 right-5">
-            <NButton size="large" @click="menuStore.setMenu('sermons')" circle secondary>
+            <NButton size="large" @click="closeToSermons" circle secondary>
                 <template #icon>
                     <NIcon>
                         <Close />

--- a/FrontEndApp/src/Views/CreateSermon/YoutubeShare.vue
+++ b/FrontEndApp/src/Views/CreateSermon/YoutubeShare.vue
@@ -111,11 +111,16 @@ function resetForm() {
     loading.value = false;
     isPublished.value = false;
 }
+
+function closeToSermons() {
+    menuStore.growInitialScreen = 'sermons';
+    menuStore.setMenu('grow');
+}
 </script>
 <template>
     <div class="h-[100%] w-[100%]">
         <div class="absolute top-5 right-5">
-            <NButton size="large" @click="menuStore.setMenu('sermons')" circle secondary>
+            <NButton size="large" @click="closeToSermons" circle secondary>
                 <template #icon>
                     <NIcon>
                         <Close />

--- a/FrontEndApp/src/Views/Grow/Grow.vue
+++ b/FrontEndApp/src/Views/Grow/Grow.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { Icon } from '@iconify/vue';
+import Sermons from '../Sermons/Sermons.vue';
+import { useMenuStore } from '../../store/menu';
+
+type Screen = 'hub' | 'sermons';
+
+const menuStore = useMenuStore();
+const activeScreen = ref<Screen>('hub');
+
+// Deep-link: CreateSermon/YoutubeShare set growInitialScreen before switching
+// to the Grow tab so the user lands on Sermons instead of the hub.
+watch(
+    () => menuStore.growInitialScreen,
+    (screen) => {
+        if (screen) {
+            activeScreen.value = screen;
+            menuStore.growInitialScreen = null;
+        }
+    },
+    { immediate: true }
+);
+</script>
+
+<template>
+    <div class="h-full flex flex-col overflow-hidden">
+        <!-- Hub -->
+        <div
+            v-show="activeScreen === 'hub'"
+            class="flex-1 min-h-0 overflow-y-auto p-4 max-w-2xl mx-auto w-full space-y-3"
+        >
+            <h1 class="text-xl font-bold text-[var(--theme-text)] pt-1">Grow</h1>
+            <p class="text-sm text-[var(--theme-text-soft)]">
+                Resources to help you grow in the Word.
+            </p>
+            <div
+                class="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-elevated)] p-4 cursor-pointer hover:shadow-md transition-shadow"
+                @click="activeScreen = 'sermons'"
+            >
+                <div class="flex items-start gap-4">
+                    <div
+                        class="w-12 h-12 rounded-xl flex items-center justify-center text-2xl shrink-0"
+                        style="background: #8b5cf622"
+                    >
+                        🎙️
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <p class="font-semibold text-sm text-[var(--theme-text)]">Sermons</p>
+                        <p class="text-xs text-[var(--theme-text-soft)] mt-0.5">
+                            Browse, favorite, and share sermons.
+                        </p>
+                    </div>
+                    <span class="text-[var(--theme-text-soft)] text-lg">&rsaquo;</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Sermons: kept mounted (v-show) so the requestedTab watcher and
+             scroll state behave exactly as when it lived directly in App.vue -->
+        <div v-show="activeScreen === 'sermons'" class="flex-1 min-h-0 flex flex-col">
+            <div class="px-4 pt-2 shrink-0">
+                <button
+                    class="flex items-center gap-1 text-sm text-[var(--theme-text-soft)] hover:text-[var(--theme-text)] cursor-pointer bg-transparent border-none"
+                    @click="activeScreen = 'hub'"
+                >
+                    <Icon icon="mdi:arrow-left" /> Grow
+                </button>
+            </div>
+            <div class="flex-1 min-h-0">
+                <Sermons />
+            </div>
+        </div>
+    </div>
+</template>

--- a/FrontEndApp/src/components/Settings/Tabs/TabSetting.vue
+++ b/FrontEndApp/src/components/Settings/Tabs/TabSetting.vue
@@ -10,7 +10,7 @@ const menuStore = useMenuStore();
         <NCheckboxGroup v-model:value="menuStore.enableTab">
             <div class="flex flex-col gap-3">
                 <div>
-                    <NCheckbox :label="$t('Sermons')" value="sermons" />
+                    <NCheckbox :label="$t('Grow')" value="grow" />
                     <p class="text-xs opacity-50 mt-0.5 ml-6">{{ $t('manage-sermons-desc') }}</p>
                 </div>
                 <div>

--- a/FrontEndApp/src/store/menu.ts
+++ b/FrontEndApp/src/store/menu.ts
@@ -6,12 +6,10 @@ import session from './../util/session';
 import { renderNIcon } from '../util/helper';
 import {
     Book24Filled,
-    DocumentQueueMultiple24Filled,
     Person24Filled,
     Settings24Filled,
     HeartCircle24Filled,
     Book24Regular,
-    DocumentQueueMultiple24Regular,
     Person24Regular,
     HeartCircle24Regular,
     Settings24Regular,
@@ -21,6 +19,8 @@ import {
     Sparkle24Filled,
     Games24Regular,
     Games24Filled,
+    LeafTwo24Regular,
+    LeafTwo24Filled,
 } from '@vicons/fluent';
 import { PrayingHands } from '@vicons/fa';
 
@@ -28,6 +28,10 @@ export const useMenuStore = defineStore('useMenuStore', () => {
     const menuSelected = ref<string>('read-bible');
     const router = useRouter();
     const isRouter = ref<boolean>(false);
+    // Deep-link signal: set to 'sermons' before selecting the 'grow' tab to
+    // land directly on the Sermons screen instead of the hub. Grow.vue
+    // consumes and clears it.
+    const growInitialScreen = ref<'sermons' | null>(null);
     const menuSessionKey = 'menu-session';
     const mainStore = useMainStore();
 
@@ -40,10 +44,10 @@ export const useMenuStore = defineStore('useMenuStore', () => {
             iconDark: renderNIcon(Book24Filled),
         },
         {
-            label: 'Sermons',
-            key: 'sermons',
-            icon: renderNIcon(DocumentQueueMultiple24Regular),
-            iconDark: renderNIcon(DocumentQueueMultiple24Filled),
+            label: 'Grow',
+            key: 'grow',
+            icon: renderNIcon(LeafTwo24Regular),
+            iconDark: renderNIcon(LeafTwo24Filled),
         },
         {
             label: 'Prayer List',
@@ -95,7 +99,7 @@ export const useMenuStore = defineStore('useMenuStore', () => {
     const localSavedTabsKey = 'localSavedTabsKey';
     const enableTab = ref([
         'read-bible',
-        'sermons',
+        'grow',
         '/prayer-list',
         '/daily-devotional',
         '/ai-assistant',
@@ -175,6 +179,13 @@ export const useMenuStore = defineStore('useMenuStore', () => {
                 savedLocalTabsKey = savedLocalTabsKey.filter((t: string) => t !== '/games');
                 session.set(localSavedTabsKey, savedLocalTabsKey);
             }
+            // Sermons moved under the Grow hub: migrate saved tab lists.
+            if (savedLocalTabsKey.includes('sermons')) {
+                savedLocalTabsKey = Array.from(
+                    new Set(savedLocalTabsKey.map((t: string) => (t === 'sermons' ? 'grow' : t)))
+                );
+                session.set(localSavedTabsKey, savedLocalTabsKey);
+            }
 
             enableTab.value = session.get(localSavedTabsKey);
         }
@@ -182,6 +193,8 @@ export const useMenuStore = defineStore('useMenuStore', () => {
         const savedMenu: { isRouter: boolean; menuSelected: string } | undefined | null = session.get(menuSessionKey);
 
         if (savedMenu) {
+            // Sermons moved under the Grow hub: migrate saved selection.
+            if (savedMenu.menuSelected === 'sermons') savedMenu.menuSelected = 'grow';
             await setMenu(savedMenu.menuSelected);
             return;
         }
@@ -190,6 +203,7 @@ export const useMenuStore = defineStore('useMenuStore', () => {
     return {
         menuSelected,
         isRouter,
+        growInitialScreen,
         setMenu,
         setMenuWithNoRoute,
         menuUpperTabs,

--- a/FrontEndApp/src/store/webBillingStore.ts
+++ b/FrontEndApp/src/store/webBillingStore.ts
@@ -68,11 +68,9 @@ export type ManageResult =
 export const useWebBillingStore = defineStore('webBillingStore', () => {
     const authStore = useAuthStore();
 
-    // Master kill-switch for web/desktop checkout. Paddle (RevenueCat Web
-    // Billing) is not yet verified for production, so all purchasing on
-    // desktop/web is disabled — the UI falls back to a "subscribe in the mobile
-    // app" notice (see MobileOnlyNotice.vue). Flip to `true` once Paddle is live.
-    const CHECKOUT_ENABLED = false;
+    // Master kill-switch for web/desktop checkout. Keep this true only after
+    // Paddle/RevenueCat production setup is approved and ready for live checkout.
+    const CHECKOUT_ENABLED = true;
 
     /** Whether web purchasing is available (configured AND enabled). */
     const supported = !!WEB_KEY && CHECKOUT_ENABLED;

--- a/Modules Turso/Commentaries/Believers Sword/gen_lev_22_26.py
+++ b/Modules Turso/Commentaries/Believers Sword/gen_lev_22_26.py
@@ -1,0 +1,544 @@
+"""Generate Leviticus 22-26 commentaries and insert into DB."""
+import sqlite3, json, uuid, os, pathlib
+from datetime import datetime, timezone
+
+DB_PATH = "believers_sword_commentaries.db"
+PROGRESS_JSON = "commentary_generation_progress.json"
+LOG_FILE = "commentary_generation_log.jsonl"
+GENERATED_DIR = pathlib.Path("generated")
+
+COLLECTION_ID = 1
+COLLECTION_NAME = "Believers Sword Commentaries"
+BATCH_ID = str(uuid.uuid4())
+
+NOW = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+COMMENTARIES = [
+    {
+        "book_id": 3,
+        "book": "Leviticus",
+        "chapter": 22,
+        "title": "Holy Offerings and Unblemished Sacrifices: Reverence at the Altar",
+        "summary": "Leviticus 22 guards the holiness of the sacrificial system by regulating who may eat the sacred portions and requiring that all animals offered to God be without defect—pointing to the unblemished Lamb of God who takes away the sin of the world.",
+        "content": "Leviticus 22 continues the extended discussion of holiness begun in chapter 17, now narrowing to two specific concerns: the protection of the holy food portions set aside for priests, and the requirement that every animal offered to the LORD be physically perfect. Together these twin concerns paint a picture of a God who is worthy of the very best and who will not accept a diminished or dishonest offering.\n\n**Who May Eat the Holy Offerings (vv. 1–16)**\nThe sacred portions allocated to priests—grain offerings, sin offerings, guilt offerings, wave offerings—are guarded by strict access rules. A priest who is ritually unclean (due to skin disease, bodily discharge, contact with the dead, or contact with an unclean animal) may not eat until he has bathed and the sun has set. The holiness of the food reflects the holiness of the God to whom it was offered, and consuming it in an unclean state would profane it.\n\nThe rules extend to the priest's household. His permanently-owned slaves may eat the holy portions, but a priest's daughter who has married a non-priest loses access. If she returns to her father's house as a widow or divorcee without children, she may eat again. The logic is one of household membership: the holy portions belong to the priestly household, and membership determines access.\n\nVerse 15 warns that the priests must not allow the holy gifts to be profaned by permitting unauthorized people to eat them. Holiness must be actively maintained, not passively assumed.\n\n**Requirements for Acceptable Sacrifices (vv. 17–33)**\nThe second section establishes that no animal offered to the LORD may have a blemish (mum). This applies whether the offering comes from an Israelite or from a resident foreigner—the standard is universal. The list of disqualifying defects is detailed: blindness, injury, mutilation, boil, scab, or discharge.\n\nA few nuanced exceptions follow:\n- An ox or sheep \"that has a limb too long or too short\" may be offered as a freewill offering but not for a vow offering (v. 23). The freewill offering, given from spontaneous generosity rather than religious obligation, permitted slightly more latitude.\n- Castrated animals are excluded (v. 24).\n- A newborn animal must remain with its mother for seven days before it may be sacrificed (v. 27)—a natural and humane provision.\n- A cow or ewe and its young must not be slaughtered on the same day (v. 28)—echoing the principle of Deuteronomy 22:6–7.\n\nThe chapter closes with its refrain: \"I am the LORD who sanctifies you\" (v. 32). God is the source of holiness; the commands do not generate holiness but respond to and preserve it.\n\n**Theological Significance**\nThe requirement that every sacrifice be without blemish is one of the Old Testament's clearest pointers to Christ. When Peter writes that believers are redeemed \"with the precious blood of Christ, like that of a lamb without blemish or spot\" (1 Peter 1:19), he is drawing directly from this passage. The Mosaic system required unblemished animals as shadows of the reality: the Son of God, who was perfectly without sin (2 Corinthians 5:21; Hebrews 4:15), offering Himself as the ultimate sacrifice. Every blemished animal rejected at the altar was a preached sermon: only a perfect offering will do.",
+        "chapter_overview": "Leviticus 22 regulates access to the holy priestly food portions and requires all sacrificial animals to be without physical defect. The twin emphases—purity of those who handle holy things, and perfection of what is offered—anticipate Christ as both the unblemished sacrifice and the sinless High Priest.",
+        "original_language_notes": [
+            {
+                "term": "mum",
+                "language": "Hebrew",
+                "verse": "20",
+                "words_used": "blemish / defect",
+                "meaning": "A physical defect disqualifying an animal from sacrifice. Used in both Leviticus 21 (for priests) and 22 (for animals), deliberately linking the purity of the offerer and the offering. The same concept applies typologically to Christ in 1 Peter 1:19."
+            },
+            {
+                "term": "qorban",
+                "language": "Hebrew",
+                "verse": "18",
+                "words_used": "offering / that which is brought near",
+                "meaning": "From the root qarav, 'to draw near.' A sacrifice is literally 'that which draws near'—the animal or gift brought into proximity with God. The offering mediates access to God's presence."
+            },
+            {
+                "term": "nedavah",
+                "language": "Hebrew",
+                "verse": "23",
+                "words_used": "freewill offering",
+                "meaning": "A voluntary, spontaneous offering motivated by gratitude or love rather than legal obligation. The freewill offering received slightly more latitude in animal selection, reflecting its nature as a gift of the heart rather than a fulfillment of a vow."
+            },
+            {
+                "term": "hillel",
+                "language": "Hebrew",
+                "verse": "32",
+                "words_used": "profane / dishonor",
+                "meaning": "To make common, pierce, or defile what is holy. The opposite of qadash (to sanctify). The chapter ends with God asserting that He will not be profaned—He is the LORD who sanctifies Israel."
+            }
+        ],
+        "moral_lessons": [
+            "Offerings to God must represent our best, not our leftovers—a blemished gift dishonors the One it is meant to honor.",
+            "Holiness is contagious in the right direction: handling holy things requires preparation and purity.",
+            "The consistent standard for sacrifice—animal must be without defect—anticipates the only sacrifice that truly atones: Christ, without sin.",
+            "Access to God's presence is a privilege that must not be taken for granted or treated carelessly."
+        ],
+        "application": "Leviticus 22 challenges the tendency to give God our remainders—the time left after everything else, the money left after all expenses, the energy left after personal pursuits. The unblemished sacrifice principle is not abolished in Christ; it is fulfilled in Him and reflected back to us in Romans 12:1—offering our bodies as 'living sacrifices, holy and acceptable to God.' The standard for what we bring to God has not lowered; Christ has raised it by fulfilling the ultimate requirement and now calls us to whole-hearted devotion.",
+        "prayer": "Father, You accepted nothing less than perfection for the atonement of our sins, and You provided that perfection in Your Son. Forgive us for the blemished offerings we bring—half-hearted worship, distracted prayer, partial obedience. By Your Spirit, transform us into worshippers who offer You our best. Thank You for the Lamb without blemish who qualified where we could not. Amen.",
+        "key_points": [
+            "Holy food portions may be eaten only by ritually clean priests and qualifying household members.",
+            "Every sacrificial animal must be physically unblemished—the LORD will not accept a second-rate offering.",
+            "The unblemished sacrifice requirement is the OT foundation for understanding Christ as the spotless Lamb (1 Peter 1:19).",
+            "Freewill offerings allowed slightly more latitude than vow offerings, reflecting the different character of spontaneous generosity.",
+            "God is the sanctifier: 'I am the LORD who sanctifies you' (v. 32)—holiness is received, not manufactured."
+        ],
+        "study_questions": [
+            "Why does the holiness of the food portions depend on the ritual state of the one consuming them?",
+            "What is the theological significance of requiring unblemished animals for sacrifice?",
+            "How does 1 Peter 1:19 interpret the Leviticus 22 requirement in light of Christ?",
+            "What is the difference between a vow offering and a freewill offering, and what does this difference reveal about the nature of each?",
+            "How does Romans 12:1 apply the 'unblemished sacrifice' principle to Christian living?"
+        ],
+        "tags": ["sacrifice", "holiness", "blemish", "Christ", "typology", "priestly portions", "worship"],
+        "sources": ["Leviticus 22 (ESV)", "1 Peter 1:19", "Hebrews 4:15", "Romans 12:1", "2 Corinthians 5:21"]
+    },
+    {
+        "book_id": 3,
+        "book": "Leviticus",
+        "chapter": 23,
+        "title": "The Appointed Feasts: God's Calendar of Redemption",
+        "summary": "Leviticus 23 presents the seven appointed feasts of the LORD—Sabbath, Passover, Unleavened Bread, Firstfruits, Weeks, Trumpets, Day of Atonement, and Booths—as a divine calendar that rehearses Israel's redemption and pre-figures the full sweep of Christ's saving work.",
+        "content": "Leviticus 23 is one of the most theologically rich chapters in all the Old Testament. It presents seven 'appointed feasts' (mo'adim—'appointed times' or 'sacred assemblies') as God's own calendar, describing them not as Israel's feasts but as 'the LORD's appointed feasts' (v. 2). They are not merely annual holidays but rehearsals of redemptive history—enacted prophecy pointing forward to the Messiah.\n\n**The Weekly Sabbath (v. 3)**\nBefore listing the annual feasts, the LORD anchors the calendar in the weekly Sabbath. Six days of work and one day of rest mirrors creation (Genesis 2:2–3). The Sabbath is holy convocation—a sacred assembly—even in one's own home. It provides the rhythmic pulse within which all other appointed times are set.\n\n**Passover and Unleavened Bread (vv. 4–8)**\nPassover (Pesach) on the 14th of the first month (Nisan) commemorates the night God passed over the blood-marked homes of Israel in Egypt (Exodus 12). The following seven days are the Feast of Unleavened Bread—no leaven in the home, a week-long remembrance of Israel's hasty departure and the putting away of sin. These are the foundational feasts upon which Israel's identity rests.\n\nNew Testament fulfillment: Christ is our Passover lamb, sacrificed on the 14th of Nisan (1 Corinthians 5:7). He rose during the Feast of Unleavened Bread, the day after the Sabbath—the very day of Firstfruits.\n\n**Firstfruits (vv. 9–14)**\nOn the day after the Sabbath during Unleavened Bread, Israel was to wave a sheaf of the first grain harvest before the LORD. The firstfruits sheaf was not the whole harvest but its pledge—the guarantee that the rest would follow. No harvest could be eaten until the firstfruits were waved.\n\nNew Testament fulfillment: Paul explicitly calls Christ 'the firstfruits of those who have fallen asleep' (1 Corinthians 15:20, 23). His resurrection is the firstfruits guarantee that all who belong to Him will also be raised. He rose on exactly this feast day.\n\n**Weeks / Pentecost (vv. 15–22)**\nFifty days after Firstfruits (hence the Greek name Pentecost), Israel celebrated the end of the grain harvest with wave offerings of two loaves of leavened bread—the only leavened offering in the sacrificial system. The inclusion of leaven, scholars suggest, represents the incorporation of sinful humanity (leaven = sin elsewhere) into God's redeemed community.\n\nThe chapter pauses here to repeat the command to leave grain at the field edges for the poor and the sojourner (v. 22)—a startling insertion in a list of feast days, reminding Israel that proper worship is inseparable from care for the vulnerable.\n\nNew Testament fulfillment: The Holy Spirit was poured out on the Day of Pentecost (Acts 2), exactly 50 days after Christ's resurrection on Firstfruits. The church—composed of sinners from every nation—is the leavened loaves, redeemed and waved before God.\n\n**Trumpets (vv. 23–25)**\nThe first day of the seventh month (Tishri) was marked by trumpet blasts and a day of rest. The precise meaning is not explained in Leviticus, though it has traditionally been associated with divine remembrance and the gathering of God's people. In Jewish tradition this became Rosh Hashanah (New Year).\n\nNew Testament possible fulfillment: Many see this as pointing to the rapture/resurrection trumpet of 1 Thessalonians 4:16–17 and 1 Corinthians 15:52.\n\n**Day of Atonement (vv. 26–32)**\nThe 10th of Tishri is Yom Kippur—the most solemn day of the year. The people are to 'afflict themselves' (fast and humble their souls) and do no work. Anyone who fails to afflict himself is cut off from the people. The Day of Atonement is the annual cleansing of the sanctuary and the covering of all Israel's sins, described in detail in Leviticus 16.\n\nNew Testament fulfillment: Hebrews 9 interprets Christ's death as the ultimate Yom Kippur. He entered not a tent made with hands but heaven itself, with His own blood, to secure an eternal redemption.\n\n**Booths / Tabernacles (vv. 33–44)**\nThe 15th through 21st of Tishri was the Feast of Booths (Sukkot), with a solemn assembly on the 22nd. For seven days Israel lived in temporary shelters, remembering the wilderness wanderings. It was also a harvest festival—a time of great joy at the culmination of the agricultural year.\n\nNew Testament possible fulfillment: The coming Messianic Kingdom, when God will 'tabernacle' with His people (Revelation 21:3), may be the ultimate fulfillment of Booths. John 1:14—'the Word became flesh and dwelt [tabernacled] among us'—may also echo this feast.\n\n**The Calendar as Prophecy**\nThe remarkable thing about these seven feasts is that the first four (Passover, Unleavened Bread, Firstfruits, Pentecost) were all fulfilled by Christ in exact chronological sequence at His first coming. The final three (Trumpets, Atonement, Booths) remain unfulfilled—pointing to what is yet to come at His return. The calendar is not merely a liturgical schedule but a prophetic outline of redemptive history.",
+        "chapter_overview": "Leviticus 23 presents seven divinely appointed feasts—Sabbath, Passover, Unleavened Bread, Firstfruits, Weeks, Trumpets, Atonement, and Booths—as God's own calendar. The first four were fulfilled in precise chronological sequence by Christ at His first coming; the final three point toward His return and the consummation of all things.",
+        "original_language_notes": [
+            {
+                "term": "mo'adim",
+                "language": "Hebrew",
+                "verse": "2",
+                "words_used": "appointed feasts / appointed times",
+                "meaning": "From the root ya'ad, 'to appoint or meet.' The feasts are literally 'appointments'—times God set in advance to meet with His people and enact the drama of redemption. The same word is used for the Tent of Meeting (ohel mo'ed)."
+            },
+            {
+                "term": "pesach",
+                "language": "Hebrew",
+                "verse": "5",
+                "words_used": "Passover",
+                "meaning": "From pasach, 'to pass over, to spare.' The name recalls the night the angel of death passed over blood-marked homes in Egypt. Paul uses this typology in 1 Corinthians 5:7: 'Christ our Passover has been sacrificed.'"
+            },
+            {
+                "term": "omer",
+                "language": "Hebrew",
+                "verse": "10",
+                "words_used": "sheaf (of grain)",
+                "meaning": "A bundle or sheaf of grain—the first portion of the harvest waved before the LORD as a pledge of the full harvest to come. Paul calls the resurrected Christ the 'firstfruits' (aparche in Greek), drawing on this exact imagery."
+            },
+            {
+                "term": "inah nefesh",
+                "language": "Hebrew",
+                "verse": "27",
+                "words_used": "afflict yourselves / humble your souls",
+                "meaning": "Literally 'to humble/afflict the soul (nefesh).' The idiom for fasting and self-humiliation on the Day of Atonement. It encompasses not just food abstention but the whole posture of broken, penitent waiting before God."
+            }
+        ],
+        "moral_lessons": [
+            "God ordains sacred rhythms of rest, remembrance, and celebration—Israel's year was shaped by worship, not merely work.",
+            "The feasts teach that redemption is not a one-time memory but an annually renewed experience of God's saving acts.",
+            "Care for the poor (v. 22) belongs within the calendar of worship—right liturgy and right ethics are inseparable.",
+            "The fulfillment of the spring feasts in Christ builds confidence that the unfulfilled fall feasts will be equally precisely fulfilled."
+        ],
+        "application": "The appointed feasts teach every generation of God's people that time itself is holy—not just Sundays or special services, but all of life ordered around remembrance of what God has done. Christians observe the substance the feasts foreshadowed: the Lord's Supper rehearses Passover; baptism enacts the crossing of the Red Sea; the gift of the Spirit fulfills Pentecost. Reading Leviticus 23 with New Testament eyes transforms these feasts from ancient ceremonies into living theology, and fills the believer with confidence that the God who kept His calendar at Christ's first coming will complete it at His return.",
+        "prayer": "LORD of all time and seasons, Your calendar is perfect and Your purposes will not fail. Thank You for Christ, our Passover, our Firstfruits, the One whose resurrection guarantees ours. Thank You for the Spirit poured out at Pentecost. We eagerly await the fulfillment of what remains—the trumpet call, the final atonement of all things, and the eternal Tabernacles when You will dwell with us forever. Come, Lord Jesus. Amen.",
+        "key_points": [
+            "The seven feasts are 'the LORD's appointed times'—divine appointments in the calendar of redemptive history.",
+            "The first four spring feasts were fulfilled by Christ in exact chronological sequence at His first coming.",
+            "The Day of Atonement is the theological heart of the calendar—the annual covering of sin pointing to Christ's final sacrifice (Hebrews 9).",
+            "Care for the poor is embedded in the feast calendar (v. 22)—worship and justice are inseparable.",
+            "The three fall feasts remain prophetic—pointing toward Christ's return and the consummation of redemption."
+        ],
+        "study_questions": [
+            "How do the seven appointed feasts function as 'enacted prophecy'—telling the story of redemption through ritual?",
+            "In what ways did Christ fulfill the first four feasts in exact sequence? How does this historical correspondence strengthen Christian faith?",
+            "Why is the Feast of Weeks (Pentecost) described with leavened loaves—unlike all other grain offerings?",
+            "Why does the passage interrupt the feast calendar to insert the command about leaving grain for the poor (v. 22)?",
+            "What does the Feast of Booths reveal about the nature of the coming Kingdom and God's ultimate purpose for dwelling with His people?"
+        ],
+        "tags": ["feasts", "Passover", "Pentecost", "Atonement", "Tabernacles", "typology", "Christ", "calendar", "prophecy"],
+        "sources": ["Leviticus 23 (ESV)", "1 Corinthians 5:7", "1 Corinthians 15:20-23", "Acts 2", "Hebrews 9", "John 1:14", "Revelation 21:3"]
+    },
+    {
+        "book_id": 3,
+        "book": "Leviticus",
+        "chapter": 24,
+        "title": "The Lampstand, the Showbread, and the Sanctity of God's Name",
+        "summary": "Leviticus 24 moves from sacred time to sacred space and sacred speech: instructions for the lampstand and showbread that maintain God's presence in the tabernacle, followed by an incident of blasphemy that establishes the inviolable sanctity of the divine name and the principle of proportionate justice.",
+        "content": "Leviticus 24 brings together two apparently unrelated topics—the tabernacle furnishings and a legal judgment—but they share a common thread: the holiness of God's name and the seriousness of profaning what is holy.\n\n**The Lamp and the Bread (vv. 1–9)**\nThe first section returns to themes from Exodus 25–27, providing ongoing maintenance instructions for two central tabernacle furnishings:\n\n*The Lampstand (vv. 1–4):* Pure olive oil, beaten rather than pressed, must be provided by the people to keep the seven-branched menorah burning continually before the LORD. Aaron is responsible to tend it from evening to morning. The menorah is not merely a light source but a symbol of God's presence—the light of the divine presence in the midst of Israel. Its unbroken burning represents the unbroken nature of God's covenant presence among His people.\n\n*The Showbread (vv. 5–9):* Each Sabbath, Aaron is to set out twelve loaves of bread in two rows of six on the pure gold table before the LORD—one loaf for each of the twelve tribes. Each loaf is made with two-tenths of an ephah of fine flour. Fresh incense is placed on each row. On the following Sabbath, the priests eat the bread in the holy place; Aaron and his sons receive it as a 'most holy' portion. The showbread (literally 'bread of the Presence' or 'face-bread') represents Israel's perpetual offering before God and God's perpetual provision for His people. The weekly renewal on the Sabbath ties Israel's feeding to God's covenant rhythm.\n\nThe two furnishings together—light and bread—evoke themes later developed in the New Testament. Jesus declares Himself 'the light of the world' (John 8:12) and 'the bread of life' (John 6:35). He is the reality toward which the menorah and showbread pointed.\n\n**The Blasphemy Incident and Its Aftermath (vv. 10–23)**\nA jarring narrative interrupts: the son of an Israelite woman and an Egyptian man gets into a fight with an Israelite man and 'blasphemes the Name and curses' (v. 11). Moses brings him to the LORD for judgment. The verdict is stunning in its clarity: the blasphemer must be stoned to death. The principle is universal—whether Israelite or foreigner, 'whoever blasphemes the name of the LORD shall be put to death' (v. 16).\n\nThe principle of equal application is then extended into the lex talionis: fracture for fracture, eye for eye, tooth for tooth. The well-known phrase has often been misread as a license for vengeance, but its original function was exactly the opposite—it was a *limit* on punishment, ensuring that punishment is proportionate to the offense and equal before the law regardless of social status. The foreigner is treated identically to the native Israelite: one standard for all.\n\nMoses executes the judgment as commanded, and the chapter ends with a formulaic note: 'The people of Israel did as the LORD commanded Moses.'\n\n**The Theology of the Name**\nWhy is blasphemy of the divine name a capital offense? Because the name of God is not merely a label—it is a revelation of His character, His identity, and His covenant relationship with Israel. In the ancient world, a name carried the essence of its bearer. To blaspheme the Name is not to insult a word but to assault the character of the living God who has graciously revealed Himself. The severity of the penalty reflects the immense dignity of the One whose name has been attacked.\n\nThis connects directly to the Third Commandment: 'You shall not take the name of the LORD your God in vain' (Exodus 20:7). The Hebrew for 'in vain' is la-shav—for emptiness, for worthlessness. Using God's name without weight, without reverence, or in cursing is to treat as worthless the most precious revelation in creation.",
+        "chapter_overview": "Leviticus 24 combines maintenance instructions for the tabernacle lampstand and showbread with a case law about blasphemy. Together, these establish the theology of God's ongoing presence among His people (light and bread) and the inviolable sanctity of His name, enforced through proportionate, impartial justice.",
+        "original_language_notes": [
+            {
+                "term": "ha-Shem",
+                "language": "Hebrew",
+                "verse": "11",
+                "words_used": "the Name",
+                "meaning": "The divine name YHWH was so sacred that later Jewish practice substituted 'ha-Shem' ('the Name') in speech. Verse 11's blasphemer 'blasphemed the Name'—attacking the covenant identity and character of the LORD Himself."
+            },
+            {
+                "term": "lechem ha-panim",
+                "language": "Hebrew",
+                "verse": "5",
+                "words_used": "bread of the Presence / showbread",
+                "meaning": "Literally 'bread of faces/presence.' The loaves were set before the face of God—a perpetual, visible gift representing Israel's dependence on God and His provision for them. Jesus echoes this as 'the bread of life' in John 6."
+            },
+            {
+                "term": "menorah",
+                "language": "Hebrew",
+                "verse": "4",
+                "words_used": "lampstand",
+                "meaning": "The seven-branched golden lampstand, beaten from a single piece of gold (Exodus 25:31). Its unbroken flame symbolized God's continuous, faithful presence with Israel. The seven lamps later appear in Revelation 1 as the seven churches—those who bear God's light in the world."
+            },
+            {
+                "term": "ayin tachat ayin",
+                "language": "Hebrew",
+                "verse": "20",
+                "words_used": "eye for eye",
+                "meaning": "The lex talionis—proportionate justice. The phrase establishes a ceiling on punishment, not a floor. Its purpose is equal justice under the law regardless of social standing, not a mandate for personal revenge. Jesus reinterprets this in Matthew 5:38–39, moving from judicial principle to personal ethics."
+            }
+        ],
+        "moral_lessons": [
+            "The things of God—His name, His presence, His word—are to be handled with reverence, not carelessness.",
+            "The same standard applies to everyone: impartial justice reflects the impartial character of God.",
+            "God's presence is not automatic or self-sustaining from the human side—it requires ongoing maintenance, offering, and attention.",
+            "The lex talionis is not a charter for vengeance but a limit on it—justice means proportionate, equal response."
+        ],
+        "application": "The principle behind the lampstand and showbread still applies: maintaining the light of God's presence in the church requires ongoing effort, offering, and Sabbath-rhythmed renewal. The sobering incident with the blasphemer warns against casual or contemptuous use of God's name—whether in speech, in liturgy, or in life. The Third Commandment is still in force. And Jesus' radical expansion of the lex talionis (Matthew 5:38–42) does not abolish proportionate justice in civil society; it calls individuals to a higher personal ethic of grace.",
+        "prayer": "Holy Father, Your name is great and Your presence is our life. Forgive us for careless speech and half-hearted worship. Keep the light burning in our hearts and communities—the light of Your Word, Your Spirit, and Your Son, who declared Himself the light of the world and the bread of life. May we handle holy things with holy reverence. Amen.",
+        "key_points": [
+            "The menorah must burn continually—God's presence in the tabernacle is perpetual, not occasional.",
+            "The twelve loaves of showbread represent Israel's perpetual offering before God and God's provision for all twelve tribes.",
+            "Blasphemy of the divine name is a capital offense because the name reveals God's character and covenant identity.",
+            "The lex talionis establishes proportionate, impartial justice—a ceiling on punishment, not a mandate for vengeance.",
+            "Jesus identifies Himself as the fulfillment of both the lampstand ('light of the world') and the showbread ('bread of life')."
+        ],
+        "study_questions": [
+            "What does the perpetual burning of the menorah communicate about God's relationship with Israel?",
+            "Why is the showbread renewed weekly on the Sabbath? What is the theological significance of that timing?",
+            "Why is blasphemy treated as a capital crime in Israel? What does this reveal about the nature of God's name?",
+            "How does the lex talionis function as a limit on punishment rather than a license for it? How does Jesus build on this principle in Matthew 5?",
+            "In what ways do the lampstand and showbread point forward to Christ?"
+        ],
+        "tags": ["lampstand", "showbread", "blasphemy", "divine name", "lex talionis", "justice", "presence", "Christ"],
+        "sources": ["Leviticus 24 (ESV)", "John 6:35", "John 8:12", "Exodus 25:31", "Matthew 5:38-39", "Revelation 1:12-13"]
+    },
+    {
+        "book_id": 3,
+        "book": "Leviticus",
+        "chapter": 25,
+        "title": "Sabbath Year and Jubilee: God's Economics of Grace",
+        "summary": "Leviticus 25 establishes the sabbatical year and the Year of Jubilee as God's radical economic calendar—rest for the land, liberation for debt-slaves, and the return of family land—grounding Israel's social order in the theological reality that the earth belongs to the LORD and all Israelites are His servants.",
+        "content": "Leviticus 25 is one of the most socially revolutionary chapters in the entire Bible. It establishes two interrelated institutions—the Sabbatical Year (every seventh year) and the Jubilee (every fiftieth year)—that restructure Israel's economic life around theological principles rather than market forces. At the heart of the chapter is a simple, world-inverting declaration: 'the land is mine' (v. 23). If the land belongs to God, then Israelites are not owners but stewards; and if the people belong to God (v. 55), then permanent human slavery is impossible.\n\n**The Sabbatical Year (vv. 1–7)**\nEvery seventh year, the land is to lie fallow. No sowing, pruning, or commercial harvesting. What grows by itself may be eaten by the owner, servants, hired workers, resident aliens, and even livestock and wild animals—but there is no commercial crop. The land 'rests' (shabbat) as a Sabbath to the LORD.\n\nThis is not simply good ecology (though it is that—soil needs periodic rest). It is a profound theological statement: Israel does not own the land; they are tenants. The land's rest is an acted-out acknowledgment that the LORD is the ultimate owner.\n\n**The Jubilee Year (vv. 8–55)**\nAfter seven sabbatical cycles (49 years), the 50th year is proclaimed by a trumpet blast on Yom Kippur: the Jubilee year. Three transformations occur:\n\n*1. Liberty throughout the land (vv. 8–17):* All sold land reverts to its original tribal family. Economic transactions from the previous Jubilee cycle are calculated accordingly—you are effectively buying years of use, not permanent title.\n\n*2. Trust in God's provision (vv. 18–22):* The natural anxiety is: what will we eat in the seventh year (when we cannot plant) and the following eighth year (when the new crop is not yet harvested)? God's answer: 'I will command my blessing on you in the sixth year, so that it will produce a crop sufficient for three years' (v. 21). The Jubilee requires radical trust in divine provision.\n\n*3. Redemption of persons (vv. 23–55):* If an Israelite falls into poverty and must sell himself or his land, both may be redeemed by a kinsman-redeemer (go'el)—a relative who pays the redemption price. If no redeemer is available, the Jubilee liberates both the person and the land at the 50th year. Importantly, Israelites may not be treated as permanent slaves—they are 'servants of the LORD' and may not be enslaved by one another permanently.\n\nThe institution of the kinsman-redeemer (go'el) is one of the Old Testament's richest theological concepts. Boaz functions as Ruth's go'el in the book of Ruth. More significantly, the concept becomes a central metaphor for God Himself—Isaiah 41:14, 43:14, 44:6 all call God the go'el of Israel. And supremely, Christ functions as our go'el: He pays our redemption price, restores our forfeited inheritance, and liberates us from bondage.\n\n**Jubilee and the Kingdom**\nJesus' inaugural sermon at Nazareth (Luke 4:18–19) quotes Isaiah 61—a passage that itself draws on Jubilee language. 'The Spirit of the Lord is upon me… to proclaim liberty to captives… to proclaim the year of the Lord's favor.' Jesus announces that Jubilee has arrived in Him—the ultimate liberation of those enslaved to sin and the restoration of the inheritance forfeited at the Fall.",
+        "chapter_overview": "Leviticus 25 establishes the Sabbatical Year and Jubilee Year as God's economic calendar—built on the theological foundation that land and people belong to God, not to human masters. The kinsman-redeemer institution anticipates Christ as our go'el who pays our redemption price and restores our inheritance.",
+        "original_language_notes": [
+            {
+                "term": "yovel",
+                "language": "Hebrew",
+                "verse": "10",
+                "words_used": "Jubilee",
+                "meaning": "Possibly derived from the ram's horn (yoveil) blown to proclaim the Jubilee, or from a root meaning 'to be carried along.' The Jubilee is the year of liberation, return, and restoration—proclaimed by the blowing of the shofar on Yom Kippur."
+            },
+            {
+                "term": "go'el",
+                "language": "Hebrew",
+                "verse": "25",
+                "words_used": "kinsman-redeemer / avenger",
+                "meaning": "The close relative with the right and obligation to redeem a family member's land or person. From ga'al, 'to redeem, restore, avenge.' God is Israel's go'el (Isaiah 44:6); Christ is our go'el—paying the redemption price to restore what was lost."
+            },
+            {
+                "term": "deror",
+                "language": "Hebrew",
+                "verse": "10",
+                "words_used": "liberty / freedom",
+                "meaning": "A specific term for the proclamation of release, especially in Jubilee contexts. Isaiah 61:1 uses this same word for the freedom the Servant of the LORD will proclaim—the passage Jesus quotes in Luke 4:18 to announce His ministry as Jubilee fulfillment."
+            },
+            {
+                "term": "shabbat shabbaton",
+                "language": "Hebrew",
+                "verse": "4",
+                "words_used": "sabbath of solemn rest",
+                "meaning": "A doubled emphatic—'a Sabbath of Sabbaths'—indicating the intensified rest of the sabbatical year for the land. The same phrase is used for the Day of Atonement (Lev. 16:31). The most sacred rest is applied to the land itself."
+            }
+        ],
+        "moral_lessons": [
+            "Ultimate ownership belongs to God—human beings are stewards, not absolute owners of land, money, or people.",
+            "Economic systems must include mechanisms for the restoration of the vulnerable; cyclical debt and slavery cannot be God's permanent design for His image-bearers.",
+            "Trust in God's provision must be practical, not just theoretical—the Jubilee required actual financial risk based on divine promise.",
+            "The concept of the kinsman-redeemer reveals that God's justice is not impersonal but deeply relational—someone near to us pays our debt."
+        ],
+        "application": "Leviticus 25 is not directly applicable as civil law for modern nations, but its theological principles are timeless. The earth belongs to the LORD (Psalm 24:1); human beings are stewards. The liberation announced in Jubilee is fulfilled in Christ—He has proclaimed the year of the LORD's favor (Luke 4:18–19), liberating those enslaved to sin and restoring the forfeited inheritance. The church is called to embody Jubilee ethics: generous care for the poor, advocacy for those trapped in cycles of poverty, and the proclamation of the ultimate liberation that only Christ provides.",
+        "prayer": "LORD God, the earth is Yours and everything in it. Forgive us for grasping what we cannot own and for failing to care for those whose resources have been stripped away. Thank You for Christ, our kinsman-redeemer, who paid the full price for our liberation. Grant us Jubilee hearts—generous, liberating, restorative—and hasten the day when Your Kingdom comes in its fullness and all things are made new. Amen.",
+        "key_points": [
+            "The Sabbatical Year (every 7th) rests the land as an acknowledgment that it belongs to God, not Israel.",
+            "The Jubilee Year (every 50th) returns sold land to original families and liberates Israelite debt-servants.",
+            "The kinsman-redeemer (go'el) is Israel's mechanism for personal redemption—anticipating Christ as our divine go'el.",
+            "The Jubilee is grounded in one principle: 'the land is mine' (v. 23) and 'the people of Israel are my servants' (v. 55).",
+            "Jesus' inaugural sermon at Nazareth (Luke 4:18–19) announces Himself as the fulfillment of Jubilee—the ultimate year of the LORD's favor."
+        ],
+        "study_questions": [
+            "How does the theological principle 'the land is mine' (v. 23) undermine both absolute ownership and permanent slavery?",
+            "What anxieties would the Sabbatical and Jubilee years create, and how does God address them? What does this require of Israel?",
+            "How does the institution of the kinsman-redeemer (go'el) function theologically? In what ways does Christ fulfill this role?",
+            "How does Jesus' use of Isaiah 61 in Luke 4:18–19 connect His ministry to Jubilee themes?",
+            "What aspects of Jubilee ethics should inform how Christians think about economics, poverty, and wealth today?"
+        ],
+        "tags": ["Jubilee", "sabbatical year", "redemption", "kinsman-redeemer", "go'el", "liberty", "economics", "Christ", "stewardship"],
+        "sources": ["Leviticus 25 (ESV)", "Luke 4:18-19", "Isaiah 61:1-2", "Isaiah 44:6", "Ruth 4", "Psalm 24:1"]
+    },
+    {
+        "book_id": 3,
+        "book": "Leviticus",
+        "chapter": 26,
+        "title": "Covenant Blessings and Curses: The Stakes of the Covenant",
+        "summary": "Leviticus 26 presents the covenant's two trajectories in stark relief—lavish blessing for obedience and escalating judgment for persistent rebellion—framed by God's covenant promise to remember and restore even the most wayward Israel, pointing forward to the gospel of grace.",
+        "content": "Leviticus 26 is the great covenant warning chapter—a counterpart to Deuteronomy 28 and one of the Bible's most powerful presentations of the reality that covenant relationship with God is not automatic or unconditional. It stands as the climax of the Leviticus legislation, summarizing the stakes with terrifying clarity and astonishing mercy.\n\n**The Foundation (vv. 1–2)**\nBefore listing blessings and curses, the chapter restates the two most fundamental demands: no idols, no graven images; keep the Sabbaths; reverence the sanctuary. These three commands (related to the first and fourth commandments) are the heart of the covenant relationship—they define what it means to have the LORD as your God.\n\n**The Blessings of Obedience (vv. 3–13)**\nIf Israel walks in God's statutes and keeps His commands, the result will be:\n- Rain in its season and abundant harvests—the land itself will cooperate with Israel's faithfulness.\n- Peace in the land—no predators, no sword, lying down in safety.\n- Victory over enemies—five will chase a hundred, a hundred will chase ten thousand.\n- Fruitfulness and multiplication.\n- God walking among them and being their God—the covenant formula fulfilled: 'I will walk among you and will be your God, and you shall be my people' (v. 12).\n\nThe blessing is not merely material—it is relational. The highest promise is God's presence. The land of milk and honey is wonderful, but what makes Israel truly blessed is that the LORD Himself walks among them.\n\n**The Escalating Curses (vv. 14–39)**\nIf Israel refuses to obey, the consequences are presented in five escalating 'waves,' each introduced by the phrase 'if you will not listen to me' and 'if despite this you will not listen.' The pattern is critical: the curses are not immediate destruction but a graduated series of corrective disciplines, each more severe than the last:\n\n1. *First wave (vv. 14–17):* Terror, disease, crop failure, defeat by enemies.\n2. *Second wave (vv. 18–20):* Sevenfold punishment, iron sky (no rain), bronze earth (barren soil).\n3. *Third wave (vv. 21–22):* Wild animals that bereave Israel of children and destroy livestock.\n4. *Fourth wave (vv. 23–26):* Sword, pestilence, famine—ten women baking bread in a single oven (a sign of desperate scarcity).\n5. *Fifth wave (vv. 27–39):* Siege, cannibalism of children, destruction of high places, scattered among the nations, pursued by the sound of a blowing leaf.\n\nThe escalating structure reveals that the curses are not punitive vengeance but corrective discipline. God says 'seven times' because He is not trying to destroy Israel but to bring them back. The increase of punishment corresponds to the increase of stubborn rebellion.\n\n**The Promise of Restoration (vv. 40–46)**\nThis is the chapter's stunning reversal. After the terror of the fifth wave, the chapter turns: if the exiled Israel confesses their iniquity and the iniquity of their fathers, if they humble their uncircumcised hearts and accept their punishment, God will remember His covenant with Jacob, Isaac, and Abraham—and with the land. He will not utterly destroy them or break His covenant with them.\n\nThis passage is the theological basis for the prophets' message of hope. Isaiah, Jeremiah, Ezekiel, and the post-exilic books all draw on the restoration promise of Leviticus 26. Even in the exile—the most extreme application of the fifth-wave curse—the door of restoration remains open because the covenant is grounded in God's faithfulness, not Israel's performance.\n\nThe chapter ends with the covenant formula: these are the statutes that God made with Israel at Sinai. The Mosaic covenant is not the final word—it reveals the problem (Israel cannot keep it) and points to the solution: the new covenant in which God will circumcise hearts (Deuteronomy 30:6) and write His law within (Jeremiah 31:33).",
+        "chapter_overview": "Leviticus 26 presents the covenant's dual outcome: magnificent blessing for obedience (culminating in God's presence) and five escalating waves of discipline for rebellion. But the chapter's most surprising element is its restoration promise—even in exile, God will remember His covenant. This sets the theological stage for the prophets and for the new covenant in Christ.",
+        "original_language_notes": [
+            {
+                "term": "chukotim",
+                "language": "Hebrew",
+                "verse": "3",
+                "words_used": "statutes",
+                "meaning": "From chaqaq, 'to inscribe, engrave.' The statutes are literally 'engraved' ordinances—permanent, binding, not optional. The chapter opens with the requirement to walk in these inscribed ways."
+            },
+            {
+                "term": "hithalekti",
+                "language": "Hebrew",
+                "verse": "12",
+                "words_used": "I will walk among you",
+                "meaning": "From halak (to walk) in the hitpael reflexive stem—'I will walk back and forth among you.' The same verb is used for God walking in Eden (Genesis 3:8). The covenant blessing restores the garden intimacy lost at the Fall."
+            },
+            {
+                "term": "arlu lev",
+                "language": "Hebrew",
+                "verse": "41",
+                "words_used": "uncircumcised heart",
+                "meaning": "The heart not yet cut away from its rebellion and self-sufficiency. The image picks up the covenant sign of circumcision and applies it to the inner life. The cure is not physical but spiritual—Deuteronomy 30:6 promises that God Himself will circumcise the heart; Paul picks this up in Romans 2:29 and Colossians 2:11."
+            },
+            {
+                "term": "zacharti",
+                "language": "Hebrew",
+                "verse": "42",
+                "words_used": "I will remember",
+                "meaning": "From zachar, 'to remember'—but in Hebrew, divine remembering is not merely cognitive recall; it is covenantal action. When God 'remembers,' He acts in accordance with the relationship. 'I will remember my covenant' means 'I will act faithfully according to my covenant commitment.'"
+            }
+        ],
+        "moral_lessons": [
+            "The blessings and curses of Leviticus 26 reveal that obedience and disobedience have real consequences—moral cause and effect is built into God's governance of the world.",
+            "God's discipline is graduated and corrective, not immediately destructive—the escalation pattern reveals a God who pursues relationship, not judgment.",
+            "The highest blessing is not prosperity but God's presence: 'I will walk among you and will be your God.'",
+            "Even the worst failure cannot eliminate God's covenant memory—the door of repentance and restoration always remains open."
+        ],
+        "application": "Leviticus 26 presents the covenant's stakes in stark terms, but its last word is grace. This pattern—obedience leads to blessing, disobedience to discipline, repentance to restoration—runs through all of Scripture and through every believer's life. The new covenant in Christ means we face no condemnation (Romans 8:1), but the principle of sowing and reaping remains (Galatians 6:7). God disciplines those He loves (Hebrews 12:5–11). And when we confess and return, He is faithful and just to forgive (1 John 1:9). The story of Leviticus 26 is the story of every prodigal—and every prodigal's Father.",
+        "prayer": "LORD, You are faithful even when we are faithless. Thank You for the graduated patience of Your discipline—that You pursue us with correction before destruction, and that even in exile Your face does not turn away permanently. Thank You that in Christ, the full weight of covenant curse has fallen on Him so that covenant blessing might be ours. Restore us, renew our hearts, and walk among us again. Amen.",
+        "key_points": [
+            "The covenant blessings culminate not in prosperity but in God's presence walking among His people.",
+            "The curses are graduated across five waves, each preceded by an opportunity for repentance—they are corrective, not merely punitive.",
+            "Leviticus 26:40–46 is the restoration promise that grounds the prophets' hope in exile—God will remember His covenant.",
+            "The 'uncircumcised heart' (v. 41) is the underlying problem; God promises circumcision of the heart as the ultimate cure (Deuteronomy 30:6).",
+            "Christ bears the full weight of the covenant curses (Galatians 3:13) so that Leviticus 26's blessings may be received by faith."
+        ],
+        "study_questions": [
+            "What is the significance of the five escalating waves of discipline? What does the graduated structure reveal about God's character and purpose?",
+            "Why does the passage say 'I will walk among you' (v. 12) is the climax of the blessings? What does this reveal about God's ultimate goal?",
+            "How does the restoration promise in vv. 40–46 function as the theological foundation for the prophets' message of hope in exile?",
+            "What does 'uncircumcised heart' mean, and how does Deuteronomy 30:6 and the new covenant address this problem?",
+            "How does Galatians 3:13 interpret Christ's death in light of the covenant curses of Leviticus 26 and Deuteronomy 28?"
+        ],
+        "tags": ["covenant", "blessings", "curses", "obedience", "discipline", "restoration", "exile", "presence", "grace"],
+        "sources": ["Leviticus 26 (ESV)", "Deuteronomy 28", "Deuteronomy 30:6", "Jeremiah 31:33", "Galatians 3:13", "Romans 8:1", "Hebrews 12:5-11"]
+    }
+]
+
+
+def get_or_create_collection(conn):
+    c = conn.cursor()
+    c.execute("SELECT id FROM commentary_collections WHERE slug='believers-sword-commentaries'")
+    row = c.fetchone()
+    if row:
+        return row[0]
+    c.execute("""
+        INSERT INTO commentary_collections (name, slug, language_code, description, created_at, updated_at)
+        VALUES (?, ?, 'en', 'Believers Sword Bible Commentaries', ?, ?)
+    """, (COLLECTION_NAME, 'believers-sword-commentaries', NOW, NOW))
+    conn.commit()
+    return c.lastrowid
+
+
+def chapter_exists(conn, collection_id, book_id, chapter):
+    c = conn.cursor()
+    c.execute("""
+        SELECT id, content FROM commentary_entries
+        WHERE collection_id=? AND book_id=? AND chapter=? AND language_code='en'
+          AND reference_scope='chapter' AND deleted_at IS NULL
+    """, (collection_id, book_id, chapter))
+    row = c.fetchone()
+    if not row:
+        return False
+    content = row[1] or ""
+    return len(content) > 300
+
+
+def insert_entry(conn, collection_id, entry):
+    c = conn.cursor()
+    entry_uuid = str(uuid.uuid4())
+    c.execute("""
+        INSERT INTO commentary_entries (
+            uuid, collection_id, author_type, language_code, theological_perspective,
+            status, book_id, chapter, verse_start, verse_end, reference_scope,
+            title, summary, content, chapter_overview, original_language_notes,
+            moral_lessons, application, prayer, key_points, study_questions,
+            tags, sources, created_at, updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,NULL,NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, (
+        entry_uuid, collection_id, "ai", "en", "evangelical",
+        "draft", entry["book_id"], entry["chapter"], "chapter",
+        entry["title"], entry["summary"], entry["content"],
+        entry["chapter_overview"],
+        json.dumps(entry["original_language_notes"]),
+        json.dumps(entry["moral_lessons"]),
+        entry["application"], entry["prayer"],
+        json.dumps(entry["key_points"]),
+        json.dumps(entry["study_questions"]),
+        json.dumps(entry["tags"]),
+        json.dumps(entry["sources"]),
+        NOW, NOW
+    ))
+    conn.commit()
+    return entry_uuid
+
+
+def save_json_backup(entry, entry_uuid):
+    book_id_str = str(entry["book_id"]).zfill(2)
+    book_slug = entry["book"].lower().replace(" ", "-")
+    folder = GENERATED_DIR / f"{book_id_str}-{book_slug}"
+    folder.mkdir(parents=True, exist_ok=True)
+    chapter_str = str(entry["chapter"]).zfill(2)
+    filepath = folder / f"{chapter_str}.json"
+    data = {
+        "uuid": entry_uuid,
+        "collection_name": COLLECTION_NAME,
+        "author_type": "ai",
+        "language_code": "en",
+        "theological_perspective": "evangelical",
+        "status": "draft",
+        "book_id": entry["book_id"],
+        "book": entry["book"],
+        "chapter": entry["chapter"],
+        "title": entry["title"],
+        "summary": entry["summary"],
+        "content": entry["content"],
+        "chapter_overview": entry["chapter_overview"],
+        "original_language_notes": entry["original_language_notes"],
+        "moral_lessons": entry["moral_lessons"],
+        "application": entry["application"],
+        "prayer": entry["prayer"],
+        "key_points": entry["key_points"],
+        "study_questions": entry["study_questions"],
+        "tags": entry["tags"],
+        "sources": entry["sources"],
+        "created_at": NOW,
+        "updated_at": NOW
+    }
+    # Verify no forbidden keys
+    for fk in ["is_ai_generated", "model_name", "prompt_version"]:
+        assert fk not in data, f"Forbidden key {fk} found!"
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    return str(filepath)
+
+
+def update_progress(conn, next_book_id, next_book, next_chapter,
+                    last_book_id, last_book, last_chapter, completed=False):
+    c = conn.cursor()
+    c.execute("SELECT id FROM commentary_generation_progress LIMIT 1")
+    row = c.fetchone()
+    data = {
+        "next_book_id": next_book_id,
+        "next_book": next_book,
+        "next_chapter": next_chapter,
+        "last_completed_book_id": last_book_id,
+        "last_completed_book": last_book,
+        "last_completed_chapter": last_chapter,
+        "completed": completed,
+        "updated_at": NOW
+    }
+    if row:
+        c.execute("""
+            UPDATE commentary_generation_progress
+            SET next_book_id=?, next_book=?, next_chapter=?,
+                last_completed_book_id=?, last_completed_book=?, last_completed_chapter=?,
+                completed=?, updated_at=?
+            WHERE id=?
+        """, (next_book_id, next_book, next_chapter,
+              last_book_id, last_book, last_chapter,
+              1 if completed else 0, NOW, row[0]))
+    else:
+        c.execute("""
+            INSERT INTO commentary_generation_progress
+            (next_book_id, next_book, next_chapter, last_completed_book_id,
+             last_completed_book, last_completed_chapter, completed, updated_at)
+            VALUES (?,?,?,?,?,?,?,?)
+        """, (next_book_id, next_book, next_chapter,
+              last_book_id, last_book, last_chapter,
+              1 if completed else 0, NOW))
+    conn.commit()
+    with open(PROGRESS_JSON, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def append_log(batch_id, start_ref, end_ref, generated, skipped, db_inserted, files_written):
+    entry = {
+        "timestamp": NOW,
+        "generation_batch_id": batch_id,
+        "start_reference": start_ref,
+        "end_reference": end_ref,
+        "chapters_generated": generated,
+        "chapters_skipped": skipped,
+        "db_rows_inserted": db_inserted,
+        "files_written": files_written
+    }
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def main():
+    conn = sqlite3.connect(DB_PATH)
+    collection_id = get_or_create_collection(conn)
+
+    generated_count = 0
+    skipped_count = 0
+    db_inserted = 0
+    files_written = []
+    last_entry = None
+
+    for entry in COMMENTARIES:
+        book_id = entry["book_id"]
+        book = entry["book"]
+        chapter = entry["chapter"]
+
+        if chapter_exists(conn, collection_id, book_id, chapter):
+            print(f"SKIP: {book} {chapter} (already exists)")
+            skipped_count += 1
+            last_entry = entry
+            continue
+
+        entry_uuid = insert_entry(conn, collection_id, entry)
+        filepath = save_json_backup(entry, entry_uuid)
+
+        # Verify JSON parses and has no forbidden keys
+        with open(filepath, "r", encoding="utf-8") as f:
+            parsed = json.load(f)
+        for fk in ["is_ai_generated", "model_name", "prompt_version"]:
+            assert fk not in parsed, f"Forbidden key {fk} in {filepath}!"
+
+        print(f"GENERATED: {book} {chapter} -> {filepath} (uuid={entry_uuid})")
+        generated_count += 1
+        db_inserted += 1
+        files_written.append(filepath)
+        last_entry = entry
+
+    # Determine next progress
+    # Leviticus has 27 chapters; after ch 26, next is ch 27
+    next_chapter = 27  # Leviticus 27
+    next_book_id = 3
+    next_book = "Leviticus"
+    last_book_id = 3
+    last_book = "Leviticus"
+    last_chapter = 26
+
+    update_progress(conn, next_book_id, next_book, next_chapter,
+                    last_book_id, last_book, last_chapter)
+
+    start_ref = f"Leviticus 22"
+    end_ref = f"Leviticus 26"
+    append_log(BATCH_ID, start_ref, end_ref, generated_count, skipped_count, db_inserted, files_written)
+
+    conn.close()
+    print(f"\nDone. Generated={generated_count}, Skipped={skipped_count}, DB rows={db_inserted}, Files={len(files_written)}")
+    print(f"Next: {next_book} {next_chapter}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Modules Turso/Commentaries/Believers Sword/gen_lev_22_27.py
+++ b/Modules Turso/Commentaries/Believers Sword/gen_lev_22_27.py
@@ -1,0 +1,453 @@
+"""Generate commentaries for Leviticus 22-27 and insert into DB."""
+import sqlite3, json, uuid, os, datetime
+
+DB_PATH = "/mnt/d/Projects/Personal/Believers-Sword/Modules Turso/Commentaries/Believers Sword/believers_sword_commentaries.db"
+PROGRESS_JSON = "/mnt/d/Projects/Personal/Believers-Sword/Modules Turso/Commentaries/Believers Sword/commentary_generation_progress.json"
+LOG_JSONL = "/mnt/d/Projects/Personal/Believers-Sword/Modules Turso/Commentaries/Believers Sword/commentary_generation_log.jsonl"
+GEN_DIR = "/mnt/d/Projects/Personal/Believers-Sword/Modules Turso/Commentaries/Believers Sword/generated/03-leviticus"
+
+COLLECTION_ID = 1
+BOOK_ID = 3
+BOOK = "Leviticus"
+
+COMMENTARIES = {
+    22: {
+        "title": "Holy Offerings and Holy Priests: Maintaining Sanctity in Worship",
+        "summary": "Leviticus 22 extends holiness regulations to protect the sacred offerings from defilement, outlining which priests may eat holy food, which animals are acceptable as sacrifices, and how vows and freewill offerings must be honored—all grounded in God's absolute holiness.",
+        "content": """Leviticus 22 stands as a vital companion to the previous chapter. While chapter 21 regulated the *persons* of the priests, chapter 22 regulates both priestly *participation* in holy things and the *quality* of offerings brought to God. The governing principle runs through the chapter like a refrain: "I am the LORD who sanctifies" (vv. 9, 16, 32). Holiness is not a human achievement but a divine gift—and God's gifts demand careful, reverent handling.
+
+**Priests and Holy Food (vv. 1–16)**
+The chapter opens by addressing Aaron and his sons about their handling of "the holy things of the people of Israel." A priest who is ritually unclean—whether from a skin disease, a discharge, contact with a corpse, or seminal emission—must not eat the holy portions until his impurity has been resolved through the prescribed cleansing rites and the sun has set (v. 7). This timing was significant: it required a full day's waiting, a period of conscious reflection before re-approaching the sanctuary.
+
+Significantly, the regulations extend to the priest's household. A non-priest guest or hired worker may not eat of the holy food, but a slave who is the priest's permanent property may (v. 11). A priest's daughter who marries outside the priestly family loses her right to the holy food; if she is widowed or divorced and returns to her father's house with no children, she may eat again (vv. 12–13). These careful distinctions underscore that the priestly identity was not merely occupational but deeply relational and covenantal.
+
+Verse 15–16 introduces a principle with serious implications: the priests must not "profane the holy things of the people of Israel" by allowing unauthorized persons to eat of them. To do so would bring upon those persons the guilt of a trespass offering. The priest's role was not just personal holiness but guardianship of the holiness of the entire community's worship.
+
+**Acceptable Sacrificial Animals (vv. 17–30)**
+The second section turns to the animals presented as burnt offerings, peace offerings, or votive and freewill offerings. The standard is uncompromising: the animal must be *without blemish* (v. 21). A lengthy list of disqualifying defects follows—blindness, injury, mutilation, a running sore, scabs, or any physical defect. Animals could not be offered with bruised, crushed, torn, or cut testicles (v. 24), and even animals received from foreigners as offerings were subject to scrutiny (v. 25).
+
+Two temporal rules follow (vv. 26–28):
+1. A newborn animal must remain with its mother seven days before being offered—it was not suitable for sacrifice before that point.
+2. An animal and its young must not be slaughtered on the same day—a regulation that reflects a basic moral sensitivity toward creation.
+
+These regulations carry a Christological weight the New Testament makes explicit. Peter declares that Christians were redeemed "with the precious blood of Christ, like that of a lamb without blemish or spot" (1 Peter 1:19). The unblemished offering of Leviticus is a type that points forward to the perfect, spotless sacrifice of the Son of God.
+
+**Freewill Offerings (vv. 29–30)**
+When a thanksgiving offering is made, it must be eaten on the same day—nothing may remain until morning. The immediacy required a full-hearted, present-moment worship: the people could not defer their encounter with grace to a more convenient time. Every offering demanded full presence.
+
+**"You Shall Be Holy, for I Am Holy" (vv. 31–33)**
+The chapter closes with the foundation of all its laws: "I am the LORD. You shall keep my commandments and do them: I am the LORD. You shall not profane my holy name, that I may be sanctified among the people of Israel. I am the LORD who sanctifies you, who brought you out of the land of Egypt to be your God: I am the LORD" (vv. 31–33). The Exodus becomes the theological ground for holiness. God did not redeem Israel from Egypt so they could live like Egypt. He redeemed them to make them a holy people who reflected his own character to the world.
+
+**Christ and the New Covenant**
+In Christ, believers become a "royal priesthood" (1 Peter 2:9). The call to approach God with reverence—with clean hands and a pure heart (Psalm 24:4)—continues into the New Covenant. The Communion table is likewise not to be approached carelessly (1 Corinthians 11:27–29). What Leviticus expresses through external regulation, the New Covenant writes on the heart by the Spirit.""",
+        "chapter_overview": "Chapter 22 regulates priestly access to holy food based on ritual purity, outlines strict standards for acceptable sacrificial animals (without blemish), and concludes with the theological foundation: God's holiness, which demands a matching reverence in all worship.",
+        "original_language_notes": [
+            {"term": "qadash", "language": "Hebrew", "verse": 9, "words_used": ["sanctifies", "sanctify"], "meaning": "To set apart, make holy; the Piel form indicates God's active work of making Israel holy, not merely declaring them so."},
+            {"term": "tamim", "language": "Hebrew", "verse": 21, "words_used": ["without blemish", "perfect"], "meaning": "Complete, whole, without defect; used of sacrificial animals and later metaphorically of moral integrity (Gen 17:1); points typologically to Christ (1 Pet 1:19)."},
+            {"term": "nedabah", "language": "Hebrew", "verse": 21, "words_used": ["freewill offering"], "meaning": "A voluntary, spontaneous offering driven by gratitude rather than obligation; the root conveys generosity and willing devotion."},
+            {"term": "chalal", "language": "Hebrew", "verse": 15, "words_used": ["profane"], "meaning": "To defile, pierce, or make common what is sacred; a serious word used when something holy is treated as ordinary."},
+            {"term": "mum", "language": "Hebrew", "verse": 21, "words_used": ["blemish", "defect"], "meaning": "A physical flaw or moral fault; used both for animal defects in sacrifice and for moral imperfection in people."}
+        ],
+        "moral_lessons": [
+            "God deserves our best—not our leftovers. The prohibition against blemished sacrifices calls us to give God quality worship, time, and devotion.",
+            "Access to God's presence is a privilege that carries responsibility. Priests could not eat holy food in a state of impurity; Christians must approach God with sincere, repentant hearts.",
+            "The sanctity of God's name is entrusted partly to us. Our behavior either honors or dishonors the God we claim to serve.",
+            "Compassion extends to creation. The rule against slaughtering an animal and its young on the same day reveals that God's moral order encompasses care for all living things."
+        ],
+        "application": "Believers today are priests who offer spiritual sacrifices to God (1 Peter 2:5). Leviticus 22 challenges us to examine the quality of what we bring to God—our worship, our service, our daily consecration. Are we bringing our best or what is convenient? Do we approach the Lord's Supper and corporate worship with reverence or routine? The chapter also reminds us that our spiritual state affects our ministry to others: an impure heart cannot effectively handle holy things. Regular self-examination, confession, and renewal keep us fit for God's service.",
+        "prayer": "Lord, You are holy and You alone sanctify us. Forgive us when we treat Your presence casually or bring You what is second-best. Purify our hearts and consecrate our worship so that everything we offer You—our praise, our service, our very lives—is worthy of Your name. Help us to be faithful stewards of the holy things You have entrusted to us. In Christ's spotless name, Amen.",
+        "key_points": [
+            "Priests in a state of ritual impurity were forbidden from eating holy food until purified and the sun had set.",
+            "Sacrificial animals must be without blemish—a standard that typologically points to Christ, the perfect Lamb (1 Peter 1:19).",
+            "The priest's household rules reveal the communal nature of priestly holiness—it extended to family members.",
+            "God's motivation for all holiness laws is the Exodus: He redeemed Israel to be a holy people reflecting His character.",
+            "Freewill offerings required full, present-moment engagement—nothing could be left until morning.",
+            "Even the timing of animal sacrifice carried moral weight: mother and young could not be killed the same day."
+        ],
+        "study_questions": [
+            "What does the repeated phrase 'I am the LORD who sanctifies you' teach about the source and nature of holiness?",
+            "How does the requirement for unblemished sacrifices prepare us to understand Christ's atoning work?",
+            "In what ways do New Testament believers function as priests (1 Peter 2:5, 9), and what does that imply about how we approach God?",
+            "What practical steps can you take this week to ensure your worship is not 'blemished' by carelessness or hypocrisy?",
+            "What does the rule about the mother and young (v. 28) suggest about God's character toward creation?"
+        ],
+        "tags": ["holiness", "priesthood", "sacrifice", "worship", "purity", "leviticus", "old-testament", "typology", "christ"],
+        "sources": ["Leviticus 22 (ESV)", "1 Peter 1:19", "1 Peter 2:5,9", "1 Corinthians 11:27-29", "Psalm 24:4", "Numbers 19"]
+    },
+    23: {
+        "title": "The Sacred Calendar: God's Appointed Times of Meeting",
+        "summary": "Leviticus 23 establishes the seven annual festivals of Israel—Sabbath, Passover, Firstfruits, Weeks, Trumpets, Day of Atonement, and Tabernacles—as 'appointed times' for worship, rest, and remembrance of God's redemptive acts.",
+        "content": """Leviticus 23 is one of the most structurally significant chapters in the entire Old Testament. It presents what the Hebrew calls the *mo'adim*—the "appointed times" or "sacred assemblies" of the Lord. These were not merely Israel's religious holidays; they were divinely scheduled appointments between the covenant God and His people. Seven feasts are listed, each carrying deep theological weight, and together they form a dramatic, yearly rehearsal of God's redemptive plan—a plan whose full realization comes in Jesus Christ.
+
+**The Weekly Sabbath (v. 3)**
+Before any annual festival, the weekly Sabbath is established as the foundational rhythm of Israel's sacred time. Every seventh day is "a Sabbath of solemn rest, a holy convocation." The Sabbath sanctified ordinary time—every week was a testimony that life belonged to God, that rest was not laziness but covenant faithfulness. In the New Testament, Christ declares Himself "Lord of the Sabbath" (Mark 2:28), and the book of Hebrews speaks of a "Sabbath rest" for the people of God that finds its ultimate fulfillment in eternal life with God (Hebrews 4:9–11).
+
+**Passover and Unleavened Bread (vv. 4–8)**
+The first annual feast is the Passover (Pesach), observed on the fourteenth day of the first month (Nisan), followed immediately by the seven-day Feast of Unleavened Bread. Together, these commemorated the defining event of Israel's existence: the Exodus. The unleavened bread recalled the haste of departure—there was no time for dough to rise. The removal of leaven from homes symbolized the purging of sin and the old life.
+
+Paul applies this directly to the Christian life: "Christ, our Passover lamb, has been sacrificed. Let us therefore celebrate the festival, not with the old leaven, the leaven of malice and evil, but with the unleavened bread of sincerity and truth" (1 Corinthians 5:7–8). The Passover is not merely recalled in Communion—it is fulfilled in Christ.
+
+**Firstfruits (vv. 9–14)**
+On the day after the first Sabbath of Unleavened Bread, a sheaf of the firstfruits of the barley harvest was to be waved before the Lord. This was an act of consecration—the first of the harvest belonged to God, and by giving it, Israel acknowledged that all the harvest was His. Paul identifies the resurrection of Christ as the "firstfruits" of those who have died (1 Corinthians 15:20–23). Christ rose on the exact day of the Firstfruits offering in the Jewish calendar—the first Sunday of Passover week—making the fulfillment precise and deliberate.
+
+**Feast of Weeks / Pentecost (vv. 15–22)**
+Exactly fifty days after Firstfruits, Israel celebrated the Feast of Weeks (Shavuot), also known as Pentecost (from the Greek for "fifty"). Two wave loaves of leavened bread were brought—unusually, leaven was permitted here. The leavened loaves have been interpreted as representing the offering of the whole, unregenerate people, or the diverse nature of those gathered into the covenant. Significantly, Pentecost was also associated with the giving of the Law at Sinai.
+
+In Acts 2, the Holy Spirit descended on the disciples on the day of Pentecost, exactly fifty days after the resurrection. The harvest of souls that followed—three thousand in one day—was a stunning fulfillment of the feast's agricultural picture.
+
+**Feast of Trumpets (vv. 23–25)**
+On the first day of the seventh month, Israel was to observe a day of rest and trumpet blasts. The chapter gives no explicit reason for the trumpets—it is the only feast without a historical explanation. This ambiguity has led Jewish tradition to associate it with the Day of Judgment and Christian eschatologists to connect it with the trumpet of God at the Second Coming (1 Thessalonians 4:16; Revelation 8–11). The feast stands as a divine summons, a call to preparation.
+
+**Day of Atonement / Yom Kippur (vv. 26–32)**
+Ten days into the seventh month (the "days of awe" between Trumpets and Atonement) comes the most solemn day in the Jewish calendar. Yom Kippur required:
+- Afflicting the soul (fasting and self-examination)
+- Absolute rest
+- Making atonement for all sin
+
+The Day of Atonement receives its full treatment in Leviticus 16. Here in chapter 23 it is placed in sequence to show its connection to the sacred calendar. The book of Hebrews devotes extensive discussion to how Christ fulfills Yom Kippur: He entered not a man-made sanctuary but heaven itself, offering not animal blood but His own (Hebrews 9:11–14, 24–28). He accomplished what no annual atonement could—a once-for-all cleansing of conscience.
+
+**Feast of Tabernacles / Sukkot (vv. 33–44)**
+The final feast is perhaps the most joyful. For seven days (with an eighth day of solemn assembly), Israel was to live in booths made of tree branches, commemorating the wilderness wandering when God sheltered His people in tents. The feast had a dual character: it was simultaneously a harvest celebration (the grain was fully in) and a memorial of God's provision in the wilderness.
+
+Zechariah prophesies that all nations will one day come to Jerusalem to celebrate the Feast of Tabernacles (Zechariah 14:16). John 1:14 says the Word "tabernacled" (skēnoō) among us—Jesus's incarnation is the ultimate Tabernacles, God dwelling with His people. Revelation 21:3 echoes the same language when describing the eternal state.
+
+**The Typological Architecture**
+Taken together, the seven feasts trace a remarkable redemptive narrative:
+- **Passover** → Christ's death
+- **Unleavened Bread** → His sinless life and our sanctification
+- **Firstfruits** → His resurrection
+- **Pentecost** → the coming of the Holy Spirit
+- **Trumpets** → the future gathering at His return
+- **Atonement** → the final judgment
+- **Tabernacles** → God's eternal dwelling with His redeemed people
+
+The sacred calendar of Israel is nothing less than a divinely authored outline of the entire Gospel.""",
+        "chapter_overview": "Leviticus 23 presents the seven 'appointed times' (mo'adim): Sabbath, Passover/Unleavened Bread, Firstfruits, Weeks/Pentecost, Trumpets, Day of Atonement, and Tabernacles. Together they form a yearly rehearsal of God's redemptive acts, each finding typological fulfillment in Christ.",
+        "original_language_notes": [
+            {"term": "mo'adim", "language": "Hebrew", "verse": 2, "words_used": ["appointed times", "feasts", "convocations"], "meaning": "Appointed meetings or set times; from ya'ad, to appoint or assemble. These are God's own appointments with His people, not merely human religious observances."},
+            {"term": "miqra", "language": "Hebrew", "verse": 2, "words_used": ["holy convocation"], "meaning": "A calling or assembly; from qara', to call. Each festival was a summons—God called Israel to gather and meet with Him."},
+            {"term": "pesach", "language": "Hebrew", "verse": 5, "words_used": ["Passover"], "meaning": "To pass over or skip; commemorates God's passing over the Israelite houses marked with blood during the last plague of Egypt (Exodus 12)."},
+            {"term": "bikkurim", "language": "Hebrew", "verse": 10, "words_used": ["firstfruits"], "meaning": "The first of the harvest; from bakar, to be firstborn. Giving firstfruits acknowledged that all the harvest belonged to God and consecrated the whole."},
+            {"term": "shabbaton", "language": "Hebrew", "verse": 3, "words_used": ["solemn rest", "complete rest"], "meaning": "A cessation, a complete stopping; an intensive form of shabbat. Not just a pause but a full, intentional rest that reflects God's rest after creation."},
+            {"term": "sukkot", "language": "Hebrew", "verse": 34, "words_used": ["booths", "tabernacles"], "meaning": "Temporary shelters or huts made of tree branches; the Feast of Sukkot commemorated Israel's wilderness journey and anticipated God's permanent dwelling with His people."}
+        ],
+        "moral_lessons": [
+            "Sacred rhythms protect us. The appointed times created a liturgical structure that prevented Israel from drifting into spiritual forgetfulness. Regular worship, Sabbath rest, and seasonal reflection do the same for believers.",
+            "Remembrance is a spiritual discipline. Each feast was a memorial—God commanded Israel to repeatedly rehearse what He had done. Christians do the same in Communion and in the practices of the church year.",
+            "Joy is commanded, not optional. The feasts, especially Tabernacles, were times of great celebration. God's redemption calls forth exuberant gratitude.",
+            "Our ordinary time is sacred time. By sanctifying the Sabbath as the base rhythm, God declared that every week carries theological weight—how we use our time reflects what we truly value."
+        ],
+        "application": "The seven feasts invite the modern believer to see God's hand not just in history but in the rhythms of time. As a royal priesthood, Christians are called to observe their own appointed times—Sunday worship, the Lord's Supper, seasons of fasting and prayer, and annual celebrations of Christ's death and resurrection. The feasts also call us to generosity: the gleaning laws embedded in this chapter (v. 22) require that the edges of the harvest be left for the poor. True worship always flows outward in care for the vulnerable.",
+        "prayer": "Father of all times and seasons, You have ordered history and our lives around Your redemptive purposes. Thank You for fulfilling every sacred appointment in Your Son. Teach us to honor the rhythm of rest and worship You have given us, to remember Your mighty acts with gratitude, and to joyfully anticipate the eternal Tabernacles when You will dwell with Your people forever. In the name of Jesus, who is our Passover, our Firstfruits, and our eternal rest, Amen.",
+        "key_points": [
+            "The seven annual feasts are called 'appointed times' (mo'adim)—divinely scheduled meetings between God and Israel.",
+            "The Sabbath is established as the foundational sacred rhythm before all annual feasts.",
+            "Passover and Unleavened Bread commemorate the Exodus and find fulfillment in Christ's sacrificial death (1 Cor 5:7).",
+            "Firstfruits points to Christ's resurrection as the firstfruits of the dead (1 Cor 15:20).",
+            "Pentecost/Weeks was fulfilled when the Holy Spirit descended on the disciples fifty days after the resurrection.",
+            "The Day of Atonement finds ultimate fulfillment in Christ's once-for-all atoning sacrifice (Hebrews 9).",
+            "The Feast of Tabernacles anticipates God's eternal dwelling with His people (John 1:14; Rev 21:3)."
+        ],
+        "study_questions": [
+            "How does the precise fulfillment of the spring feasts in Jesus's first coming strengthen your faith that the fall feasts may also be fulfilled?",
+            "What does the Sabbath teach us about rest, trust, and the nature of covenant life with God?",
+            "The gleaning law (v. 22) is embedded in the feasts chapter—what does this tell us about the connection between worship and social justice?",
+            "How does the Feast of Tabernacles shape your understanding of the incarnation (John 1:14) and the new creation (Rev 21)?",
+            "How might you incorporate a more intentional sacred calendar into your spiritual life today?"
+        ],
+        "tags": ["feasts", "sacred-calendar", "passover", "pentecost", "sabbath", "tabernacles", "typology", "christ", "leviticus"],
+        "sources": ["Leviticus 23 (ESV)", "1 Corinthians 5:7-8", "1 Corinthians 15:20-23", "Hebrews 4:9-11", "Hebrews 9:11-14", "Acts 2", "John 1:14", "Revelation 21:3", "Zechariah 14:16", "1 Thessalonians 4:16"]
+    },
+    24: {
+        "title": "The Lamp, the Bread, and the Weight of Words: Holiness in Action",
+        "summary": "Leviticus 24 covers the perpetual lamp and showbread in the tabernacle, then addresses a sobering case of blasphemy, establishing the principle of proportional justice—'an eye for an eye'—as the framework for Israel's legal life.",
+        "content": """Leviticus 24 brings together two seemingly unrelated sections: the ongoing maintenance of the tabernacle's lamp and table of showbread (vv. 1–9), followed by the disturbing case of a man who blasphemed God's name (vv. 10–23). These sections are not arbitrarily joined. Both address the sanctity of God's name and the community's response when that sanctity is violated—whether by neglect or outright assault.
+
+**The Perpetual Lamp (vv. 1–4)**
+Aaron is commanded to keep a lamp burning *continually* (tamid) before the LORD in the tabernacle. The lamps were to be maintained every evening and morning—a perpetual light before the Lord outside the veil. The oil was to be pure, beaten olive oil, and the lamp stood on the golden lampstand (menorah), the seven-branched stand hammered from a single talent of pure gold (Exodus 25:31–40).
+
+The perpetual lamp speaks of ongoing worship. God's presence was to be constantly acknowledged, not just at appointed feasts. The flame represented Israel's perpetual witness before God—their role as a light-bearing people in the darkness of the nations. Jesus later claims this identity for Himself ("I am the light of the world," John 8:12) and then extends it to His disciples ("You are the light of the world," Matthew 5:14). The lampstand in Revelation 1–2 represents the seven churches—God's light-bearing communities in the world.
+
+**The Showbread (vv. 5–9)**
+Each week, twelve loaves of bread (one for each tribe of Israel) were to be arranged in two rows on the golden table in the Holy Place. Fresh loaves replaced them every Sabbath, and the replaced bread was eaten by Aaron and his sons in the sanctuary. The bread was to remain before the LORD continuously.
+
+The showbread (lechem happanim—"bread of the Presence" or "bread of the faces") represented Israel's ongoing communion with God. Twelve loaves for twelve tribes: all of Israel was symbolically present before God at all times. This bread anticipated the Lord's Supper, where believers eat the bread of Christ's body in His presence. Jesus's declaration "I am the bread of life" (John 6:35, 48) draws directly on this imagery—He is the true bread of the Presence, the One in whose presence believers are spiritually nourished.
+
+**The Blasphemer: A Case Study in God's Honor (vv. 10–23)**
+The narrative shifts dramatically. A man of mixed heritage—his mother Israelite, his father Egyptian—gets into a fight with an Israelite. During the altercation, he "blasphemed the Name and cursed." The Hebrew is vivid: *naqab*—to pierce, to bore through, to pronounce distinctly. He did not merely curse; he specifically targeted the divine Name with contempt.
+
+The community was at a loss. What was the precedent? They brought the man to Moses and held him in custody while they waited for God's direction. This moment of uncertainty itself carries a lesson: when facing novel ethical crises, the wise response is to pause, consult the Lord, and wait rather than act rashly.
+
+God's verdict is severe: death by stoning, executed by the whole community. The execution was public and communal to demonstrate that blasphemy was not a private offense—it contaminated the covenant community. Notably, the law applied equally to the native-born Israelite and the foreigner residing among them (v. 22). God's holiness knows no favoritism.
+
+**The Lex Talionis: Eye for Eye (vv. 17–22)**
+Embedded within the blasphemy case, God establishes the *lex talionis*—the principle of proportional justice:
+- "Whoever takes a human life shall surely be put to death."
+- "Whoever takes an animal's life shall make it good, life for life."
+- "If anyone injures his neighbor, as he has done it shall be done to him: fracture for fracture, eye for eye, tooth for tooth."
+
+This principle, often misunderstood as barbaric, was actually *limiting and protective*: it prevented disproportionate retaliation. In ancient Near Eastern cultures, a minor offense could trigger a vendetta of devastating proportions. The lex talionis ensured that punishment matched crime—no more, no less. It was the foundation of civil justice, and the rabbis interpreted it as referring primarily to monetary compensation rather than literal physical retaliation.
+
+Jesus does not abolish this principle but transcends it in the Sermon on the Mount (Matthew 5:38–42), calling His followers to a higher ethic: not demanding even what is rightly theirs, going the extra mile, turning the other cheek. This is not justice suspended but justice exceeded by grace—the mark of the Kingdom of God.
+
+**Why the Name Matters**
+The severity of the blasphemy case forces us to ask: why is God's name treated with such gravity? The third commandment forbids taking God's name in vain (Exodus 20:7). In the ancient world, a name was not merely an identifier but an expression of one's essential being and character. To curse the Name was to assault God's very person and to attack the foundation upon which Israel's covenant existence rested. God's name was their security, their identity, and the source of their blessing. To blaspheme it was to tear at the fabric of everything.""",
+        "chapter_overview": "Leviticus 24 addresses the perpetual lamp and showbread as symbols of Israel's ongoing witness and communion with God, then records the blasphemy case that establishes the lex talionis—proportional justice—as a safeguard for the community and a reflection of God's equal regard for all persons under covenant.",
+        "original_language_notes": [
+            {"term": "tamid", "language": "Hebrew", "verse": 2, "words_used": ["continually", "regularly", "perpetual"], "meaning": "Always, continuously, perpetually; used for the daily burnt offering, the perpetual lamp, and the showbread—activities that were never to cease, symbolizing unbroken covenant relationship."},
+            {"term": "lechem happanim", "language": "Hebrew", "verse": 5, "words_used": ["showbread", "bread of the Presence"], "meaning": "Literally 'bread of the faces/presence'; panim means face or presence. The twelve loaves placed before God's face represented all Israel in continual communion with their God."},
+            {"term": "naqab", "language": "Hebrew", "verse": 11, "words_used": ["blasphemed", "cursed", "pronounced"], "meaning": "To pierce, bore, or distinctly pronounce; when used of the divine Name, it means to treat it with contempt or to misuse it deliberately. More severe than casual misuse."},
+            {"term": "HaShem", "language": "Hebrew", "verse": 11, "words_used": ["the Name"], "meaning": "Literally 'the Name,' used reverently by Jewish tradition in place of YHWH. In this verse it refers to the covenant name of God that was blasphemed—the most sacred name in Israelite religion."},
+            {"term": "nefesh", "language": "Hebrew", "verse": 17, "words_used": ["life", "soul", "person"], "meaning": "The total person, life-force, soul; nefesh tahath nefesh ('life for life') in the lex talionis expresses that human life has equal, sacred value—one life cannot be worth more than another."}
+        ],
+        "moral_lessons": [
+            "Worship is not episodic but continuous. The perpetual lamp and showbread teach us that acknowledging God's presence is a daily, unceasing calling—not just for special occasions.",
+            "Words carry moral weight. The blasphemy case reminds us that language about God is not trivial. Using His name carelessly or contemptibly dishonors the One who is the ground of all reality.",
+            "Justice must be proportional. The lex talionis is a moral safeguard: punishment should match the crime. Both leniency that enables harm and severity that exceeds justice are failures of the moral order.",
+            "God's law applies equally to all. The explicit statement that 'you shall have the same rule for the sojourner and for the native' (v. 22) is a remarkable assertion of equal dignity before the law."
+        ],
+        "application": "Leviticus 24 speaks to believers in several ways. First, it calls us to continuous, deliberate awareness of God's presence—not just at scheduled worship times, but in every hour. Second, it challenges us about how we use God's name. In a culture where 'Oh my God' is a common filler phrase, the blasphemy case is a bracing corrective. Third, the equal application of law to native and foreigner reminds us that the gospel is for all people equally, and Christian communities must reflect that same impartiality. Finally, Christ's transcendence of the lex talionis in Matthew 5 calls us beyond fairness to grace.",
+        "prayer": "Holy Father, Your name is above every name. Forgive us for every careless word, every thoughtless use of Your holy name, and every failure to honor You in our speech. Teach us to burn with the steady, unceasing light of Your presence in our lives. Grant us wisdom to pursue justice that is proportional and mercy that goes beyond what is deserved, following the pattern of Your Son who gave far more than justice required. In His precious name, Amen.",
+        "key_points": [
+            "The perpetual lamp in the tabernacle represented Israel's unceasing witness before God and anticipates Christ as the Light of the World (John 8:12).",
+            "The twelve loaves of showbread ('bread of the Presence') symbolized all Israel in continuous communion with God, pointing to Christ as the Bread of Life (John 6:35).",
+            "A man who blasphemed God's name was executed after due process—demonstrating the gravity with which God's name must be treated.",
+            "The lex talionis ('eye for eye') was a limiting principle preventing disproportionate retaliation, not a call for vengeance.",
+            "God's law applied equally to native Israelites and foreign residents—a striking affirmation of equal dignity.",
+            "Jesus transcends but does not abolish proportional justice, calling His followers to a higher ethic of grace and generosity (Matthew 5:38-42)."
+        ],
+        "study_questions": [
+            "What does the perpetual nature of the lamp and showbread (tamid) teach us about the nature of covenant relationship with God?",
+            "How does Jesus's claim to be 'the light of the world' (John 8:12) and 'the bread of life' (John 6:35) fulfill the symbols of Leviticus 24?",
+            "Why do you think the community waited for God's direction rather than acting immediately in the blasphemy case? What does this model for us?",
+            "How does the lex talionis function as a moral principle in modern legal systems? Where do you see its influence?",
+            "In what ways does Jesus's teaching in Matthew 5:38-42 go beyond, rather than against, the lex talionis?"
+        ],
+        "tags": ["blasphemy", "showbread", "lampstand", "justice", "lex-talionis", "holy-name", "leviticus", "old-testament"],
+        "sources": ["Leviticus 24 (ESV)", "Exodus 25:31-40", "John 8:12", "John 6:35", "Matthew 5:14", "Matthew 5:38-42", "Revelation 1-2", "Exodus 20:7"]
+    },
+    25: {
+        "title": "Sabbath for the Land: Jubilee, Release, and the Economics of Grace",
+        "summary": "Leviticus 25 establishes the Sabbath year and the Year of Jubilee—revolutionary economic institutions in which land rests, debts are managed, slaves are freed, and ancestral land returns to its family—grounding Israel's economic life in the memory of redemption and the sovereignty of God over all creation.",
+        "content": """Leviticus 25 is one of the most radical chapters in all of Scripture. It extends the principle of Sabbath—rest for persons (chapter 23) and cessation for worship (chapter 23)—to the land itself, and then climaxes in the Year of Jubilee, an institution so economically counterintuitive that many scholars debate whether it was ever fully implemented. Yet its theological significance is undeniable, and Jesus inaugurated His ministry by citing its language (Luke 4:18–19).
+
+**The Sabbath Year (vv. 1–7)**
+Every seventh year, the land of Israel was to lie fallow. No sowing, pruning, or harvesting for commercial purposes was permitted. Whatever the land produced on its own could be eaten by Israelites, their servants, hired workers, sojourners, and even animals—but no one could claim it exclusively. It was a year of radical equality: the land belonged to God, and its produce in the seventh year was shared commons.
+
+The Sabbath year carried multiple messages:
+1. **God owns the land**—Israel was tenants, not owners. "The land shall not be sold in perpetuity, for the land is mine. For you are strangers and sojourners with me" (v. 23).
+2. **Soil needs rest**—this was environmentally sound long before modern agricultural science confirmed it.
+3. **Faith over control**—the people had to trust God to provide enough in the sixth year to last through the seventh (and eighth, until the new harvest came in).
+
+**The Year of Jubilee (vv. 8–55)**
+After seven cycles of Sabbath years—49 years total—the fiftieth year was declared the Jubilee (from *yobel*, the ram's horn or trumpet sounded to proclaim it). On the Day of Atonement, the trumpet was sounded across the land, and Jubilee was proclaimed. Its three core provisions were:
+
+*1. Release from Debt-Slavery (vv. 39–55)*
+Israelites who had sold themselves into indentured servitude to pay debts were released in the Jubilee year. They could not be treated as permanent slaves; their service was more like that of a hired worker, and it had an end. Strikingly, the rationale given is theological, not economic: "For they are my servants, whom I brought out of the land of Egypt; they shall not be sold as slaves" (v. 42). Israel's freedom from Egyptian slavery made permanent human slavery within Israel theologically incoherent.
+
+*2. Return of Ancestral Land (vv. 13–28)*
+All land that had been sold returned to the original family in the Jubilee year. Since land could not be permanently transferred, what was actually being bought and sold was the number of harvests remaining until the next Jubilee—the more years remaining, the higher the price. This meant that prices were set not by speculation or market sentiment but by the remaining productive years until return.
+
+The result was a structural prevention of permanent, hereditary poverty: no family could lose their land forever. Every fifty years, the economic slate was wiped clean and families were restored to their foundational inheritance. This did not eliminate economic inequality within the fifty-year cycles, but it set a hard limit on how deep inequality could go or how long it could last.
+
+*3. Rest for the Land (vv. 11–12)*
+The Jubilee year was also a Sabbath year for the land. No planting or harvesting for profit was to occur, and the land's produce was again shared commons.
+
+**The Theology of Jubilee**
+Several profound theological principles emerge:
+
+*God's absolute ownership:* "The land is mine" (v. 23). Jubilee is not a social welfare program—it is a regular, covenantal reset that recognizes the creator's permanent claim over creation. Human ownership is always provisional and stewardly.
+
+*Redemption as the basis for social ethics:* The command to release slaves is grounded not in utilitarian calculation but in memory: "I am the LORD your God, who brought you out of the land of Egypt" (v. 38, 42, 55). Israel's ethics flowed from their experience of divine rescue. Because God freed them, they must not permanently enslave others.
+
+*The near-kinsman redeemer (go'el):* Throughout the chapter, the concept of redemption by a close relative appears repeatedly. If a man sold his land or himself into debt-slavery, a close relative could redeem (buy back) him before the Jubilee came. This is the same institution that makes Boaz's role in the book of Ruth so theologically significant, and it becomes a key metaphor for Christ's atoning work.
+
+**Christ and the Jubilee**
+Jesus began His public ministry in Nazareth by reading from Isaiah 61—a text written in Jubilee language—and declaring, "Today this Scripture has been fulfilled in your hearing" (Luke 4:21). The year of the Lord's favor, the release of captives, the opening of prison doors: these are Jubilee images. In Christ, the ultimate Jubilee has been declared. Sin's debt has been cancelled; those enslaved to sin have been freed; what was lost in the fall is being restored. The new creation (Revelation 21–22) is the cosmic Jubilee—all things returned to their original owner, all debts cancelled, the whole of creation at rest.""",
+        "chapter_overview": "Leviticus 25 presents the Sabbath Year (land fallow every 7th year) and the Year of Jubilee (every 50th year): land returns to ancestral families, debt-slaves are freed, and the land rests—all grounded in God's ownership of creation and Israel's memory of redemption from Egypt. Christ fulfills the Jubilee in Luke 4:18-19.",
+        "original_language_notes": [
+            {"term": "shemitah", "language": "Hebrew", "verse": 5, "words_used": ["release", "fallow", "Sabbath of rest for the land"], "meaning": "Release or letting go; the Sabbath year is called a shemitah—a release of the land from cultivation and debts from obligation. The same word is used in Deuteronomy 15 for the release of debts."},
+            {"term": "yobel", "language": "Hebrew", "verse": 10, "words_used": ["Jubilee", "jubilee"], "meaning": "Ram's horn or trumpet; the Jubilee year was proclaimed by blowing the shofar (ram's horn) on the Day of Atonement. The sound of the trumpet announced universal release."},
+            {"term": "go'el", "language": "Hebrew", "verse": 25, "words_used": ["redeemer", "near kinsman", "redeem"], "meaning": "Kinsman-redeemer; a close relative who had both the right and obligation to buy back land or persons sold into servitude within the family. A profound type of Christ as our Redeemer."},
+            {"term": "deror", "language": "Hebrew", "verse": 10, "words_used": ["liberty", "freedom"], "meaning": "Release, liberty; proclamation of deror meant freedom for debt-slaves. This is the exact word quoted in Isaiah 61:1 that Jesus applies to Himself in Luke 4:18—'he has sent me to proclaim liberty to the captives.'"},
+            {"term": "geulah", "language": "Hebrew", "verse": 48, "words_used": ["right of redemption", "redemption"], "meaning": "Redemption or buying back; from ga'al (to redeem). The noun geulah describes the right and act of redemption—particularly of persons and land within the covenant family."}
+        ],
+        "moral_lessons": [
+            "We are stewards, not owners. 'The land is mine,' says the LORD. This principle challenges every possessive claim we make and calls us to hold all things loosely as managers for God.",
+            "Freedom from slavery shapes how we treat others. Israel's memory of Egyptian bondage was meant to make them allergic to permanently enslaving others. Our redemption in Christ should produce similar compassion for the enslaved and oppressed.",
+            "Structural justice is part of the covenant. Jubilee was not an individual act of charity but a systemic reset built into the social order. God cares about structures that either protect or exploit the vulnerable.",
+            "Rest is an act of faith. Letting the land lie fallow required trusting God's provision. Our inability to rest often reflects a deeper failure of faith—a belief that everything depends on our own effort."
+        ],
+        "application": "Leviticus 25 speaks into our relationship with money, land, work, and freedom. For individuals, it calls for financial generosity and a loose grip on possessions, recognizing that everything we own is held in stewardship for God. For communities, it raises the question of whether our social structures perpetuate poverty or create pathways out of it. For the church, it calls us to embody the Jubilee announcement of Christ—proclaiming freedom to the spiritually enslaved, caring for the economically vulnerable, and living as people for whom the great debt has already been cancelled. The Jubilee is both a memory (Exodus) and an anticipation (new creation)—and we live between those two realities.",
+        "prayer": "Lord God, all things belong to You. Forgive us for our grasping, our hoarding, and our failure to extend the freedom we have received. Thank You that in Christ, the ultimate Jubilee has been declared—our debts cancelled, our captivity ended, our inheritance restored. Help us to live as people who have been redeemed, sharing freely what we have received, working for justice in systems that oppress, and resting in Your sovereign care. May we hear the trumpet of Jubilee in the gospel and let it reshape everything about how we live. In Jesus's name, Amen.",
+        "key_points": [
+            "Every seventh year, the land was to lie fallow—a Sabbath year recognizing that 'the land is mine,' says the LORD (v. 23).",
+            "Every fiftieth year was the Jubilee: land returned to ancestral families, debt-slaves were freed, and the land rested.",
+            "The go'el (kinsman-redeemer) could buy back land or persons before the Jubilee—a key type of Christ as our Redeemer.",
+            "The Jubilee's theological basis was the Exodus: because God freed Israel, they could not permanently enslave others.",
+            "Jesus inaugurated His ministry with Isaiah 61's Jubilee language, declaring 'the year of the Lord's favor' fulfilled in Himself (Luke 4:18-21).",
+            "The Jubilee provides a structural, systemic vision of justice—not just individual charity—rooted in God's covenant."
+        ],
+        "study_questions": [
+            "How does the principle 'the land is mine' (v. 23) challenge modern assumptions about property and ownership?",
+            "In what ways does Jesus's proclamation in Luke 4:18-21 fulfill the Year of Jubilee? What aspects of the Jubilee has He already fulfilled, and what awaits future fulfillment?",
+            "The go'el (kinsman-redeemer) is a key figure in this chapter. How does this concept illuminate Christ's atoning work?",
+            "What would it look like for a local church community to embody the Jubilee principle in their economic relationships?",
+            "The Sabbath year required trusting God's provision for three years (the sixth, seventh, and eighth). What situations in your life currently require that kind of trust?"
+        ],
+        "tags": ["jubilee", "sabbath-year", "redemption", "justice", "kinsman-redeemer", "economics", "leviticus", "typology"],
+        "sources": ["Leviticus 25 (ESV)", "Luke 4:18-21", "Isaiah 61:1-2", "Ruth 4", "Deuteronomy 15", "Revelation 21-22", "1 Peter 1:18-19"]
+    },
+    26: {
+        "title": "Blessings and Curses: The Weight of the Covenant",
+        "summary": "Leviticus 26 presents the covenant's two paths: obedience brings abundant blessing—rain, harvest, peace, and God's presence; disobedience brings escalating discipline—disease, drought, war, and exile—yet even in exile, God promises restoration for the repentant.",
+        "content": """Leviticus 26 is the covenant's great climax—a majestic, solemn statement of the blessings and curses that attend faithfulness and unfaithfulness to God. It stands as the theological capstone of the entire book of Leviticus, establishing the framework that will govern Israel's entire history. The prophets will repeatedly return to this chapter; the pattern of blessing, warning, judgment, exile, and restoration that shapes the Old Testament narrative is grounded here.
+
+**The Two Forbidden Sins (vv. 1–2)**
+The chapter opens with a preamble that identifies the two greatest threats to covenant faithfulness: idolatry and Sabbath-breaking. These two have a structural relationship—both involve replacing God with something else. Idols replace God with human-made images; Sabbath-breaking replaces God's rest with human productivity. Everything else in the covenant flows from getting these two right.
+
+**The Blessings of Obedience (vv. 3–13)**
+The first section is extraordinarily beautiful. If Israel walks in God's statutes:
+- **Timely rain and abundant harvests**—the land will be so productive that threshing season will overlap with planting season; they will eat bread to the full.
+- **Peace and security**—no sword will come through the land; Israel will lie down in safety; wild beasts will be driven out.
+- **Victory over enemies**—five Israelites will chase a hundred; a hundred will chase ten thousand.
+- **God's presence and covenant faithfulness**—"I will walk among you and will be your God, and you shall be my people" (v. 12).
+- **Freedom from slavery remembered**—"I am the LORD your God, who brought you out of the land of Egypt, that you should not be their slaves. And I have broken the bars of your yoke and made you walk erect" (v. 13).
+
+This last blessing is perhaps the most profound: the ultimate covenant blessing is not material prosperity but relational presence. "I will walk among you." This phrase anticipates the incarnation—God walking among His people in the person of Jesus Christ (John 1:14)—and the new creation, where God will "dwell with them" and "they will be his people" (Revelation 21:3).
+
+**The Escalating Curses (vv. 14–39)**
+The curses occupy far more space than the blessings, and they intensify in four waves, each introduced by "if you will not listen to me" or "if you will not yet listen to me."
+
+*First wave (vv. 14–17):* Disease, military defeat, fruitless labor. God's face will be set against them.
+
+*Second wave (vv. 18–20):* Sevenfold intensification. The sky becomes iron, the earth bronze—no rain, no harvest. The land will not yield its strength.
+
+*Third wave (vv. 21–26):* Wild animals multiply and take children; enemies come; pestilence strikes; bread is rationed. The phrase "sevenfold" appears again—God's discipline is measured and purposeful, not chaotic.
+
+*Fourth wave (vv. 27–39):* The most severe: cannibalism during siege (fulfilled in 2 Kings 6:28–29 and Lamentations 4:10), the destruction of idolatrous places, the scattering of Israel among the nations, the desolation of the land. The land will finally get its Sabbath rests—the rests Israel refused to give it (v. 34–35). The Babylonian exile lasted approximately seventy years, which 2 Chronicles 36:21 explicitly connects to this text: the land "enjoyed its Sabbaths."
+
+**The Curses as Discipline, Not Abandonment**
+What is remarkable about this chapter is that even the harshest curses are framed as *discipline*, not destruction. The purpose of escalating judgment is to bring Israel to repentance. The word *mussar* (discipline, instruction) undergirds the whole section. God is not a capricious deity who abandons His covenant; He is a faithful Father who will use whatever means necessary to bring His children back.
+
+**The Promise of Restoration (vv. 40–45)**
+The chapter does not end in doom. After the darkest moment—exile and desolation—God promises that if Israel confesses their sin and the sin of their fathers, if their uncircumcised hearts are humbled, He will remember His covenant:
+
+"Then I will remember my covenant with Jacob, and I will remember my covenant with Isaac and my covenant with Abraham, and I will remember the land" (v. 42).
+
+The covenant with the patriarchs is the bedrock beneath all of history. Even in the worst exile, even when Israel has violated every provision of Sinai, the covenant with Abraham cannot be annulled. This is grace—not earned, not deserved, but rooted in God's own faithfulness to His promises. The New Testament calls this same reality the righteousness of God (Romans 3:21–26), and it finds its ultimate expression in Christ, who bore the curse of the covenant on the cross so that its blessings might come to all who trust in Him (Galatians 3:13–14).
+
+**The Prophetic Shape of History**
+Leviticus 26 essentially provides the theological blueprint for the entire prophetic tradition. Isaiah, Jeremiah, Ezekiel, Hosea, Amos, Micah—all of them preach from within this covenant framework. Their calls to repentance, their announcements of judgment, and their promises of restoration all echo this chapter. Understanding Leviticus 26 is essential for understanding the prophets.""",
+        "chapter_overview": "Leviticus 26 presents the covenant's conditional structure: obedience brings comprehensive blessing (rain, peace, harvest, God's presence), while disobedience triggers four escalating waves of discipline ending in exile. But even exile is not the end—God promises to remember His covenant with Abraham and restore the repentant. This chapter is the theological key to the entire Old Testament prophetic tradition.",
+        "original_language_notes": [
+            {"term": "halak", "language": "Hebrew", "verse": 12, "words_used": ["walk", "walked among"], "meaning": "To walk; 'I will walk among you' (hithalakti) uses the reflexive-intensive form—God's own movement in covenant fellowship with Israel. The same root describes Enoch and Noah 'walking with God' (Gen 5:24; 6:9)."},
+            {"term": "sheva", "language": "Hebrew", "verse": 18, "words_used": ["sevenfold", "seven times"], "meaning": "Seven; in the curse section, 'seven times' (sheva) does not mean exactly 7x multiplied punishment but signifies complete, full, or total discipline—God's thorough response to persistent rebellion."},
+            {"term": "mussar", "language": "Hebrew", "verse": 28, "words_used": ["discipline", "chastise"], "meaning": "Instruction through discipline; correction from a parent or authority figure aimed at restoration, not destruction. The curses of Leviticus 26 are mussar—they are corrective, not merely punitive."},
+            {"term": "zakar", "language": "Hebrew", "verse": 42, "words_used": ["remember", "remembered"], "meaning": "To remember, to call to mind with the intention of acting; divine remembering is always active—when God 'remembers' His covenant, He acts on it. This is the turning point of the chapter."},
+            {"term": "arel", "language": "Hebrew", "verse": 41, "words_used": ["uncircumcised", "uncircumcised heart"], "meaning": "Uncircumcised, literally 'with foreskin'; an uncircumcised heart is one that is closed, hard, and resistant to God. Circumcision of the heart (Deut 30:6; Jer 4:4) is the inner reality the outward sign pointed toward."}
+        ],
+        "moral_lessons": [
+            "Obedience and flourishing are deeply connected. This does not mean that every blessing is a reward or every suffering is punishment for personal sin, but that living within God's design for human life produces genuine human flourishing.",
+            "Discipline is an expression of love, not abandonment. God's escalating consequences are the responses of a covenant Father who refuses to give up on His children. His severity is inseparable from His faithfulness.",
+            "Even the worst consequences can be reversed by repentance. No one is so far gone that genuine, humble confession cannot open the door to restoration. This is one of Scripture's most persistent hopes.",
+            "History has a moral structure. The rise and fall of nations, the seasons of blessing and hardship, are not random. God's moral governance underlies the shape of history."
+        ],
+        "application": "Leviticus 26 is not merely a historical document—it speaks directly to individual believers and to Christian communities. The pattern of disobedience → discipline → repentance → restoration is the pattern of every genuine spiritual renewal. When we experience spiritual drought—when our prayers seem lifeless, our worship rote, our love cold—the path forward is the same as it was for Israel: humble confession, return to God, and trust in His covenant faithfulness. The blessing at the heart of this chapter ('I will walk among you') is already ours in Christ (Emmanuel—God with us), and will be fully realized in the new creation. Let that future shape how we live today.",
+        "prayer": "Faithful God, You have never broken a promise. Even when Your people have turned away, Your covenant love pursues them—pursues us. Thank You that the discipline You send is the discipline of a Father who refuses to give up. Forgive us for the idols and Sabbath-breaking that signal our misplaced priorities. Circumcise our hearts, Lord—soften them toward You. And thank You that in Christ, all the curses of the covenant have been borne by Him, so that we might receive all the blessings promised to Abraham. Help us to walk with You faithfully today. In Jesus's name, Amen.",
+        "key_points": [
+            "Leviticus 26 presents the covenant's two paths: obedience brings blessing; disobedience brings escalating discipline.",
+            "The greatest covenant blessing is God's presence: 'I will walk among you and will be your God' (v. 12)—fulfilled in Christ and anticipated in the new creation.",
+            "The curses escalate in four waves, each designed to bring Israel to repentance rather than to destroy them.",
+            "The land's desolation during exile fulfilled the Sabbath years Israel had refused to keep (vv. 34-35; 2 Chronicles 36:21).",
+            "Even exile ends in a promise of restoration: God will 'remember my covenant with Jacob...Isaac...Abraham' (v. 42).",
+            "This chapter is the theological blueprint for the entire Old Testament prophetic tradition.",
+            "Christ bore the covenant curse so that Abraham's blessing might come to all who believe (Galatians 3:13-14)."
+        ],
+        "study_questions": [
+            "What does the centrality of idolatry and Sabbath-breaking in the preamble (vv. 1-2) suggest about the root of all covenant unfaithfulness?",
+            "How does God's promise to 'walk among you' (v. 12) connect to the incarnation and the new creation?",
+            "The curses escalate four times. What does this pattern reveal about God's character and purposes in discipline?",
+            "2 Chronicles 36:21 says the exile fulfilled the land's Sabbath years. What does this ironic fulfillment teach about the seriousness of covenant obligations?",
+            "How does Galatians 3:13-14 apply Leviticus 26's curse/blessing structure to Christ's atoning work?"
+        ],
+        "tags": ["covenant", "blessings", "curses", "obedience", "discipline", "restoration", "exile", "prophecy", "leviticus"],
+        "sources": ["Leviticus 26 (ESV)", "2 Chronicles 36:21", "Galatians 3:13-14", "Romans 3:21-26", "John 1:14", "Revelation 21:3", "Lamentations 4:10", "2 Kings 6:28-29"]
+    },
+    27: {
+        "title": "Vows, Dedications, and the Tithe: Honoring Promises Made to God",
+        "summary": "Leviticus 27, the book's final chapter, establishes procedures for vows and dedications of persons, animals, houses, and land to the Lord, along with tithe regulations—concluding Leviticus with the principle that promises made to God are sacred obligations that must be honored, redeemed carefully, or surrendered fully.",
+        "content": """Leviticus 27, the final chapter of the book, addresses a topic that might at first seem anticlimactic after the soaring covenant theology of chapter 26: the regulations governing vows and dedications to the LORD. Yet this chapter is a fitting conclusion precisely because it grounds all of the book's theology in the concrete act of keeping one's word. The entire covenant of Leviticus is, at its core, a commitment between God and Israel—and the laws of vows are the lens through which that covenant's seriousness becomes intensely personal.
+
+**Vows of Persons (vv. 1–8)**
+When someone made a vow to the LORD involving a person (perhaps themselves or a family member), they could fulfill it by paying a monetary equivalent. The monetary values were established by sex and age, with adult males (20–60) set at fifty shekels, adult females at thirty, and scaled proportionally for children and the elderly. The priest was authorized to adjust the payment for those too poor to afford the standard valuation (v. 8).
+
+These valuation schedules should not be read as reflecting the inherent worth of persons—Scripture affirms the equal dignity of all people (Genesis 1:26–27). Rather, they reflect economic productivity standards of the ancient Near Eastern context. More importantly, the whole system acknowledges a theological reality: a person dedicated to the LORD has infinite worth that cannot truly be monetized, yet God graciously allows a substitute payment so that ordinary life can continue without requiring literal temple service.
+
+Hannah's vow (1 Samuel 1:11) illustrates what the alternative looked like: she vowed Samuel himself to the LORD, and there was no redemption—he served in the tabernacle his entire life. When a vow was made to give a person wholly to the LORD (as in the case of Nazirites or Levites), the full dedication stood.
+
+**Vows of Animals (vv. 9–13)**
+If a clean animal was vowed to the LORD, it could not be swapped out. The moment of dedication was binding: the animal became holy, and any substitution (even swapping a good animal for a better one) made *both* animals holy. This prevents the abuse of vowing a poor animal and then exchanging it for the one you actually wanted to keep.
+
+Unclean animals that were vowed could not be offered in sacrifice but could be presented to the priest, who would appraise them. The owner could then redeem the animal by paying its value plus a twenty percent penalty (the "fifth").
+
+**Vows of Houses and Land (vv. 14–25)**
+Similar principles applied to property. A house consecrated to the LORD was valued by the priest, and the owner could redeem it by paying the appraisal value plus twenty percent. Land was valued based on its seed capacity (how much seed it took to sow it) and the number of years remaining until the Jubilee—a direct connection to chapter 25.
+
+Land that had been sold to another person before being consecrated created a more complex situation: at the Jubilee, it would pass to the priest rather than returning to the original family, since the owner had effectively alienated it through the vow.
+
+**The Devoted (Cherem): What Cannot Be Redeemed (vv. 28–29)**
+Verse 28 introduces one of the most serious categories in Israelite law: the *cherem* (devotion to destruction, or irrevocable dedication). Anything devoted (*cherem*) to the LORD—whether person, animal, or field—could not be sold or redeemed. It was "most holy to the LORD."
+
+This same word, *cherem*, appears in the conquest narratives (Joshua 6–7) where cities were "devoted to destruction" (put under the ban). Achan's sin was taking *cherem* property for himself—and the consequences were catastrophic (Joshua 7). The *cherem* expresses God's absolute claim over certain things: they pass wholly into His dominion and cannot be reclaimed by human hands.
+
+Verse 29—"No devoted person who is devoted to destruction from mankind shall be redeemed; he shall surely be put to death"—refers to persons condemned by divine decree (such as those guilty of capital crimes under the covenant). It does not authorize human beings to condemn others to *cherem* unilaterally.
+
+**The Tithe (vv. 30–33)**
+The final section establishes the tithe: a tenth of everything from the land—grain, fruit, animals—belongs to the LORD and is holy to Him. Unlike vowed offerings, the tithe was not optional or dependent on a specific vow; it was the baseline obligation of every Israelite. If someone wished to redeem (buy back) his tithe of produce, he paid the value plus twenty percent.
+
+For animals, the tithe was taken by letting the flock or herd pass under the shepherd's staff; every tenth animal that passed was holy to the LORD, regardless of its quality. It could not be exchanged. If one tried to swap a tithed animal, both animals became holy—a provision that discouraged gaming the system.
+
+The tithe theology rests on the same foundation as the Jubilee: "The land is mine" (Leviticus 25:23), and since God owns everything, a tenth returned to Him is an acknowledgment of that ownership and a regular act of faith and gratitude. Malachi would later describe withholding the tithe as robbing God (Malachi 3:8–10), while Jesus affirmed tithing in principle while calling His followers to the weightier matters of justice, mercy, and faithfulness (Matthew 23:23).
+
+**Leviticus: A Summary**
+Leviticus ends where it should: with the concrete obligations of individual devotion. The book began with the offerings that opened the way into God's presence (chapters 1–7), established the priestly system that maintained that presence (8–10), addressed the purity laws that ordered life around it (11–16), proclaimed the holiness code that shaped Israel's communal identity (17–22), established the sacred calendar (23–25), announced the covenant's consequences (26), and now concludes with the personal, voluntary, and obligatory commitments that bind individuals to God.
+
+Throughout, the message is constant: God is holy, He dwells among His people, and He calls them to reflect His holiness in every dimension of life—diet, relationships, worship, time, economics, and now in the words of their mouths. The God of Leviticus is not a distant deity satisfied with occasional ceremony; He is a present, relational, holy God whose covenant claim extends to every corner of human existence.""",
+        "chapter_overview": "Leviticus 27 establishes valuation procedures for vows involving persons, animals, and property, introduces the irrevocable cherem (devoted things), and codifies the tithe—concluding the book with the principle that promises to God are sacred and must be honored, and that a tenth of all things already belongs to the Lord as a recognition of His ownership.",
+        "original_language_notes": [
+            {"term": "cherem", "language": "Hebrew", "verse": 28, "words_used": ["devoted", "devoted to destruction", "devoted things"], "meaning": "Something irrevocably given over to God; it cannot be sold or redeemed. Used in conquest narratives for cities devoted to destruction (Josh 6-7) and here for things unconditionally consecrated to God—the most serious form of dedication."},
+            {"term": "ma'aser", "language": "Hebrew", "verse": 30, "words_used": ["tithe", "tenth"], "meaning": "A tenth; from the root 'asar, to take a tenth. The tithe was not voluntary but the obligatory acknowledgment that God owned everything. It predates the Sinai law (Abraham tithed to Melchizedek, Genesis 14:20)."},
+            {"term": "geulah", "language": "Hebrew", "verse": 13, "words_used": ["redemption", "redeem"], "meaning": "Buying back something that had passed into another's ownership; the right and act of redeeming. The twenty percent penalty acknowledged that what was consecrated to God had a higher value than its market price."},
+            {"term": "qadosh", "language": "Hebrew", "verse": 9, "words_used": ["holy", "set apart"], "meaning": "Set apart for God, sacred; once an animal was vowed, it became qadosh—holy—and could not be treated as ordinary. The moment of vowing was irreversible without a redemption procedure."},
+            {"term": "neder", "language": "Hebrew", "verse": 2, "words_used": ["vow", "vows"], "meaning": "A solemn promise or pledge made to God, usually to give something or do something in exchange for a divine favor. Vows were voluntary but, once made, were absolutely binding (Eccl 5:4-5; Num 30:2)."}
+        ],
+        "moral_lessons": [
+            "Our words to God are binding. In a culture where promises are increasingly casual, the law of vows reminds us that God takes seriously what we say to Him. Ecclesiastes 5:4-5 echoes: 'When you vow a vow to God, do not delay paying it, for he has no pleasure in fools. Pay what you vow.'",
+            "Generosity cannot be gamed. The rules preventing animal swaps and requiring a penalty for redeeming tithes reveal that God is not impressed by workarounds. Genuine devotion means giving what you promised, not finding clever substitutes.",
+            "The tithe is a statement of faith, not just finance. Giving ten percent to God is an ongoing declaration that He owns everything else. It is an act of trust: God can do more with ninety percent than we can do with a hundred.",
+            "Leviticus ends with personal responsibility. After all the corporate laws and priestly regulations, the book closes by insisting that every individual Israelite must honor their own commitments to God."
+        ],
+        "application": "Leviticus 27 calls believers to integrity in their promises to God and their stewardship of what He has given them. Have you made vows—at a dedication service, in a moment of crisis prayer, at baptism or confirmation—that you have not kept? The vow laws invite honest self-examination. The tithe laws invite a fresh examination of our financial priorities: does our giving reflect the conviction that God owns everything, or have we made Him a recipient of whatever is left over? New Covenant giving is not limited to ten percent (2 Corinthians 9:7 calls for cheerful, purposeful giving), but it cannot fall short of the principle the tithe embodies: God first.",
+        "prayer": "Lord of all things, everything I have comes from You and belongs to You. Forgive me for the vows I have spoken and not kept, and for treating Your ownership of my life and resources as optional. Help me to be a person of my word—especially to You. Teach me to tithe and give generously as an act of worship and trust, not duty and guilt. Thank You that Your Son kept every promise, fulfilled every covenant obligation, and gave Himself fully and without reservation. Make me more like Him. Amen.",
+        "key_points": [
+            "Vows of persons, animals, houses, and land could be redeemed by paying the assessed value plus twenty percent—acknowledging the sacred premium on what had been dedicated to God.",
+            "The cherem (devoted things) was an irrevocable dedication that could not be redeemed or sold—it passed wholly and permanently into God's possession.",
+            "The tithe—a tenth of produce and animals—was the obligatory acknowledgment that God owns everything.",
+            "Vows were voluntary but absolutely binding once made; Scripture repeatedly warns against making vows carelessly (Ecclesiastes 5:4-5; Numbers 30:2).",
+            "Leviticus concludes with personal devotion, completing a journey from corporate sacrifice (ch. 1-7) to individual commitment (ch. 27).",
+            "The tithe preceded the Sinai law (Abraham tithed to Melchizedek, Genesis 14:20) and is affirmed in principle by Jesus (Matthew 23:23)."
+        ],
+        "study_questions": [
+            "What does the law of vows teach us about integrity in our relationship with God? Are there promises you have made to God that you have not kept?",
+            "How does the concept of cherem (irrevocable dedication) deepen your understanding of total surrender to God?",
+            "The tithe is described as 'holy to the LORD.' What would change in your approach to giving if you genuinely believed God owns everything you have?",
+            "Leviticus begins with detailed sacrifice instructions and ends with vow and tithe laws. What does this arc suggest about the kind of covenant life God calls Israel—and us—to?",
+            "Hebrews 7:1-10 discusses Abraham's tithe to Melchizedek and connects it to Christ's priesthood. How does Leviticus 27's tithe theology inform that passage?"
+        ],
+        "tags": ["vows", "tithe", "dedication", "cherem", "stewardship", "holiness", "leviticus", "old-testament"],
+        "sources": ["Leviticus 27 (ESV)", "1 Samuel 1:11", "Joshua 6-7", "Ecclesiastes 5:4-5", "Malachi 3:8-10", "Matthew 23:23", "2 Corinthians 9:7", "Hebrews 7:1-10", "Genesis 14:20"]
+    }
+}
+
+print("Commentary data prepared. Now writing to DB and files...")

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "believers-sword-local-dev",
   "description": "Believers Sword is an application for believers community, it is used to study bible, also used for praying, social or connect with other believers.",
   "author": "JenuelDev",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "main": "./dist/main.js",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {


### PR DESCRIPTION
This pull request refactors the navigation and UI structure by moving the Sermons feature under a new "Grow" hub, updates all related navigation logic and labels, and ensures a seamless user experience when deep-linking to Sermons. It also enables web billing checkout and includes migration logic for user session data to support the new structure.

Navigation & UI Restructuring:

* The "Sermons" tab is replaced with a new "Grow" hub tab in the main navigation (`menu.ts`, `App.vue`, `TabSetting.vue`). The Grow hub contains the Sermons screen and is represented by a new icon and label. [[1]](diffhunk://#diff-9a83f789d5916c10aadea49b7865b2f442980b6f9ed2c8d4290113f507775e3cL43-R50) [[2]](diffhunk://#diff-508c59b2a137124967970b1fb3f89d29031563d960cd4b4523d64ad513751152L22-R22) [[3]](diffhunk://#diff-34a5ceb3b2bdfc8fba5acce8c7ec391d79afb425c425dc13628604d8ab77a822L13-R13)
* A new `Grow.vue` view is introduced, acting as a hub with navigation to Sermons and future resources. The Sermons component is now rendered inside Grow, with correct state and scroll preservation. [[1]](diffhunk://#diff-da86c30bebb27d29774506443f89128cc58dfd1a79e3a62655b33c3b1dc4ee2eR1-R75) [[2]](diffhunk://#diff-508c59b2a137124967970b1fb3f89d29031563d960cd4b4523d64ad513751152L196-R199)
* All navigation logic and deep-linking to Sermons is updated to route through the Grow hub, using a new `growInitialScreen` signal for context-aware transitions (e.g., after creating a sermon). [[1]](diffhunk://#diff-e79def22cc14a0ed2e6f9bbe45835f3ba045c4c6a93927eee52cba7a044a6d39L224-R225) [[2]](diffhunk://#diff-0cefe9714168583e0008104e762817cf3c228239c52df375beaa470d4b603818R114-R123) [[3]](diffhunk://#diff-292a9e64b17117df11453502a81e949a0ce7bb0b0a4277fa00508ebaae1fbca2R114-R123) [[4]](diffhunk://#diff-9a83f789d5916c10aadea49b7865b2f442980b6f9ed2c8d4290113f507775e3cR22-R34) [[5]](diffhunk://#diff-9a83f789d5916c10aadea49b7865b2f442980b6f9ed2c8d4290113f507775e3cR206)

Session Data & Migration:

* Session and tab state migration logic ensures that any saved references to "sermons" are updated to "grow" for a seamless user experience after upgrading.

Other changes:

* Web billing checkout is now enabled by default, allowing users to purchase via Paddle/RevenueCat on web/desktop.
* Bumps the application version to `1.6.5`.