### PR TITLE
Add immersive Scripture reading mode

### DIFF
--- a/Electron/IpcMainEvents/WindowEvents/BrowserWindowEvents.ts
+++ b/Electron/IpcMainEvents/WindowEvents/BrowserWindowEvents.ts
@@ -5,6 +5,10 @@ import { applyAutoLaunch } from "../../Reminders/ReminderScheduler";
 
 const MIN_SCALE = 0.75;
 const MAX_SCALE = 1.5;
+const NORMAL_MIN_WIDTH = 1226;
+const NORMAL_MIN_HEIGHT = 700;
+const IMMERSIVE_MIN_WIDTH = 360;
+const IMMERSIVE_MIN_HEIGHT = 500;
 
 function normalizeScale(scale: number) {
     if (!Number.isFinite(scale)) return 1;
@@ -66,6 +70,35 @@ const setAppScale = (win: BrowserWindow, scale: number): number => {
     return normalizedScale;
 };
 
+const setImmersiveWindowMode = (win: BrowserWindow, enabled: boolean): void => {
+    try {
+        if (win.isDestroyed()) return;
+
+        if (enabled) {
+            win.setMinimumSize(IMMERSIVE_MIN_WIDTH, IMMERSIVE_MIN_HEIGHT);
+            return;
+        }
+
+        win.setMinimumSize(NORMAL_MIN_WIDTH, NORMAL_MIN_HEIGHT);
+
+        // setMinimumSize does not grow an existing window. If the reader was
+        // made narrower, restore the normal minimum as soon as it closes.
+        if (!win.isMaximized()) {
+            const { width, height } = win.getBounds();
+            if (width < NORMAL_MIN_WIDTH || height < NORMAL_MIN_HEIGHT) {
+                win.setSize(
+                    Math.max(width, NORMAL_MIN_WIDTH),
+                    Math.max(height, NORMAL_MIN_HEIGHT),
+                    false,
+                );
+            }
+        }
+    } catch {
+        // Window teardown can race this renderer request. Keep reader
+        // open/close independent from native window sizing failures.
+    }
+};
+
 export const windowBrowserEvents = (win: BrowserWindow) => {
     win.on('maximize', () => win.webContents.send('window:maximized', true));
     win.on('unmaximize', () => win.webContents.send('window:maximized', false));
@@ -78,6 +111,9 @@ export const windowBrowserEvents = (win: BrowserWindow) => {
     });
     ipcMain.handle('getAppScale', () => getAppScale(win));
     ipcMain.handle('setAppScale', (_event, scale: number) => setAppScale(win, scale));
+    ipcMain.handle('set-immersive-window-mode', (_event, enabled: boolean) =>
+        setImmersiveWindowMode(win, enabled === true),
+    );
     // Persist current theme colors so the next launch's loading splash matches them.
     ipcMain.handle('set-splash-theme', (_event, payload) => {
         appConfig.set('setting.splashTheme', payload);

--- a/Electron/preload.ts
+++ b/Electron/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('browserWindow', {
     isWindowBrowserMaximized: () => ipcRenderer.invoke('isWindowBrowserMaximized'),
     getAppScale: () => ipcRenderer.invoke('getAppScale'),
     setAppScale: (scale: number) => ipcRenderer.invoke('setAppScale', scale),
+    setImmersiveWindowMode: (enabled: boolean) => ipcRenderer.invoke('set-immersive-window-mode', enabled),
     // Tell main the app has fully rendered, so it can close the splash and show the window.
     appReady: () => ipcRenderer.send('app-ready'),
     // Persist the current theme colors so the next launch's splash can match them.

--- a/FrontEndApp/src/App.vue
+++ b/FrontEndApp/src/App.vue
@@ -32,12 +32,14 @@ import FeedbackModal from './components/FeedbackModal.vue';
 import KeyboardShortcutsModal from './components/KeyboardShortcutsModal.vue';
 import { useAuthStore } from './store/authStore';
 import FlipBook from './Views/ReadBible/FlipBook/FlipBook.vue';
+import ImmersiveReader from './Views/ReadBible/ImmersiveReader/ImmersiveReader.vue';
 import VersionSelectModal from './Views/ReadBible/FlipBook/VersionSelectModal.vue';
 import { useRoute, useRouter } from 'vue-router';
 import { computed } from 'vue';
 
 const route = useRoute();
 const router = useRouter();
+const isElectron = Boolean(window.isElectron);
 const isPopupWindow = computed(() => route.name === 'CompareVerse' || (!window.isElectron && (route.name === 'Login' || route.name === 'SubscriptionRequired')));
 
 const isMounted = ref(false);
@@ -210,6 +212,7 @@ onBeforeUnmount(() => {
                     <SettingsModal />
                     <VersionSelectModal />
                     <FlipBook />
+                    <ImmersiveReader v-if="isElectron" />
                     <SyncAnnouncementModal />
                     <PlanModal />
                     <FeedbackModal />

--- a/FrontEndApp/src/GlobalDeclare.ts
+++ b/FrontEndApp/src/GlobalDeclare.ts
@@ -25,6 +25,7 @@ declare global {
             minimizeWindow: () => Promise<void>;
             getAppScale: () => Promise<number>;
             setAppScale: (scale: number) => Promise<number>;
+            setImmersiveWindowMode: (enabled: boolean) => Promise<void>;
             appReady: () => void;
             setSplashTheme: (payload: { bg: string; text: string; accent: string }) => Promise<void>;
             getAvailableBibles: () => Promise<Array<any>>;

--- a/FrontEndApp/src/Views/ReadBible/ImmersiveReader/ImmersiveReader.vue
+++ b/FrontEndApp/src/Views/ReadBible/ImmersiveReader/ImmersiveReader.vue
@@ -1,0 +1,528 @@
+<script lang="ts" setup>
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useImmersiveReaderStore } from '../../../store/immersiveReaderStore';
+
+const readerStore = useImmersiveReaderStore();
+
+const readingSurface = ref<HTMLElement | null>(null);
+const modifierHeld = ref(false);
+const isMac = ref(false);
+let navigationInFlight = false;
+const captureListenerOptions: AddEventListenerOptions = { capture: true };
+
+const modifierLabel = computed(() => (isMac.value ? '⌘' : 'Ctrl'));
+
+function clearModifierState() {
+    modifierHeld.value = false;
+}
+
+function updateModifierState(event: KeyboardEvent) {
+    if (!readerStore.isOpen) {
+        clearModifierState();
+        return;
+    }
+
+    modifierHeld.value = isMac.value ? event.metaKey : event.ctrlKey;
+}
+
+function scrollReadingSurface(amount: number) {
+    readingSurface.value?.scrollBy({ top: amount, behavior: 'smooth' });
+}
+
+async function changeChapter(direction: 'next' | 'prev') {
+    if (!readerStore.isOpen || readerStore.isLoading || navigationInFlight) return;
+
+    navigationInFlight = true;
+    try {
+        await readerStore.navigateChapter(direction);
+    } catch {
+        // The store owns the loading/error state. Keep the reading surface quiet.
+    } finally {
+        navigationInFlight = false;
+    }
+}
+
+function handleKeydown(event: KeyboardEvent) {
+    if (!readerStore.isOpen) return;
+
+    updateModifierState(event);
+    // The reader owns keyboard input while open. Capture at document level so
+    // existing window/document shortcuts behind the overlay never receive it.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const commandModifierHeld = event.ctrlKey || event.metaKey || event.altKey;
+    const increaseTextKey = event.key === '+' || event.key === '=';
+
+    // Ctrl/Cmd is reserved for the shortcut sheet. Other modified navigation
+    // must also be ignored; Shift+= is allowed because it produces "+".
+    if (commandModifierHeld || (event.shiftKey && !increaseTextKey)) return;
+
+    switch (event.key) {
+        case 'ArrowLeft':
+            void changeChapter('prev');
+            break;
+        case 'ArrowRight':
+            void changeChapter('next');
+            break;
+        case 'ArrowUp':
+            scrollReadingSurface(-160);
+            break;
+        case 'ArrowDown':
+            scrollReadingSurface(160);
+            break;
+        case 'Home':
+            readingSurface.value?.scrollTo({ top: 0, behavior: 'smooth' });
+            break;
+        case 'End':
+            if (readingSurface.value) {
+                readingSurface.value.scrollTo({ top: readingSurface.value.scrollHeight, behavior: 'smooth' });
+            }
+            break;
+        case '+':
+        case '=':
+            readerStore.adjustFontSize(1);
+            break;
+        case '-':
+            readerStore.adjustFontSize(-1);
+            break;
+        case 'Escape':
+            clearModifierState();
+            readerStore.close();
+            break;
+    }
+}
+
+function handleKeyup(event: KeyboardEvent) {
+    if (event.key === 'Control' || event.key === 'Meta') {
+        clearModifierState();
+        if (readerStore.isOpen) event.stopImmediatePropagation();
+        return;
+    }
+
+    // A keyup for another key can still carry the modifier state. Reconcile it
+    // so the sheet cannot remain visible after an unusual key sequence.
+    updateModifierState(event);
+    if (readerStore.isOpen) event.stopImmediatePropagation();
+}
+
+function handleWindowBlur() {
+    clearModifierState();
+}
+
+function focusReadingSurface() {
+    nextTick(() => readingSurface.value?.focus({ preventScroll: true }));
+}
+
+watch(
+    () => readerStore.isOpen,
+    (isOpen) => {
+        clearModifierState();
+        if (isOpen) focusReadingSurface();
+    },
+);
+
+watch(
+    () => [readerStore.bookTitle, readerStore.chapterNumber] as const,
+    () => {
+        if (!readerStore.isOpen) return;
+        nextTick(() => readingSurface.value?.scrollTo({ top: 0, behavior: 'auto' }));
+    },
+);
+
+onMounted(() => {
+    isMac.value = /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent);
+    document.addEventListener('keydown', handleKeydown, captureListenerOptions);
+    document.addEventListener('keyup', handleKeyup, captureListenerOptions);
+    window.addEventListener('blur', handleWindowBlur);
+    document.addEventListener('visibilitychange', handleWindowBlur);
+});
+
+onUnmounted(() => {
+    document.removeEventListener('keydown', handleKeydown, captureListenerOptions);
+    document.removeEventListener('keyup', handleKeyup, captureListenerOptions);
+    window.removeEventListener('blur', handleWindowBlur);
+    document.removeEventListener('visibilitychange', handleWindowBlur);
+    clearModifierState();
+});
+</script>
+
+<template>
+    <Teleport to="body">
+        <div
+            v-if="readerStore.isOpen"
+            class="immersive-reader"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Immersive Scripture reader"
+        >
+            <main ref="readingSurface" class="immersive-reader__scroll" tabindex="-1">
+                <article class="immersive-reader__page">
+                    <header class="immersive-reader__heading">
+                        <h1>
+                            <span>{{ readerStore.bookTitle }}</span>
+                            <span class="immersive-reader__chapter">{{ readerStore.chapterNumber }}</span>
+                        </h1>
+                    </header>
+
+                    <p v-if="readerStore.isLoading" class="immersive-reader__status" aria-live="polite">Loading…</p>
+                    <p v-else-if="readerStore.loadError" class="immersive-reader__status" aria-live="polite">
+                        Scripture unavailable.
+                    </p>
+                    <p v-else-if="readerStore.verses.length === 0" class="immersive-reader__status" aria-live="polite">
+                        No Scripture found.
+                    </p>
+                    <div v-else class="immersive-reader__verses">
+                        <p
+                            v-for="(verse, index) in readerStore.verses"
+                            :key="`${verse.verse}-${index}`"
+                            class="immersive-reader__verse"
+                            :style="{ fontSize: `${readerStore.fontSize}px` }"
+                        >
+                            <span class="immersive-reader__verse-number">{{ verse.verse }}</span>
+                            <span class="immersive-reader__verse-text">{{ verse.text }}</span>
+                        </p>
+                    </div>
+                </article>
+            </main>
+
+            <aside v-if="modifierHeld" class="immersive-reader__shortcuts" aria-label="Keyboard shortcuts">
+                <div class="immersive-reader__shortcut immersive-reader__shortcut--exit" aria-label="Escape: leave reader">
+                    <kbd class="immersive-reader__key">Esc</kbd>
+                    <span class="immersive-reader__shortcut-label">Leave</span>
+                </div>
+
+                <div class="immersive-reader__shortcut immersive-reader__shortcut--font" aria-label="Minus and plus: text size">
+                    <span class="immersive-reader__keys">
+                        <kbd class="immersive-reader__key">−</kbd>
+                        <kbd class="immersive-reader__key">+</kbd>
+                    </span>
+                    <span class="immersive-reader__shortcut-label">Text size</span>
+                </div>
+
+                <div
+                    class="immersive-reader__shortcut immersive-reader__shortcut--previous"
+                    aria-label="Left arrow: previous chapter"
+                >
+                    <kbd class="immersive-reader__key">←</kbd>
+                    <span class="immersive-reader__shortcut-label">Previous</span>
+                </div>
+
+                <div class="immersive-reader__shortcut immersive-reader__shortcut--next" aria-label="Right arrow: next chapter">
+                    <span class="immersive-reader__shortcut-label">Next</span>
+                    <kbd class="immersive-reader__key">→</kbd>
+                </div>
+
+                <div class="immersive-reader__shortcut immersive-reader__shortcut--scroll" aria-label="Up and down arrows: scroll">
+                    <span class="immersive-reader__keys">
+                        <kbd class="immersive-reader__key">↑</kbd>
+                        <kbd class="immersive-reader__key">↓</kbd>
+                    </span>
+                    <span class="immersive-reader__shortcut-label">Scroll</span>
+                </div>
+
+                <div class="immersive-reader__shortcut immersive-reader__shortcut--range" aria-label="Home and End: start or end">
+                    <span class="immersive-reader__keys">
+                        <kbd class="immersive-reader__key immersive-reader__key--wide">Home</kbd>
+                        <kbd class="immersive-reader__key immersive-reader__key--wide">End</kbd>
+                    </span>
+                    <span class="immersive-reader__shortcut-label">Start / end</span>
+                </div>
+
+                <p class="immersive-reader__shortcuts-hint">Release {{ modifierLabel }} to hide</p>
+            </aside>
+        </div>
+    </Teleport>
+</template>
+
+<style scoped lang="scss">
+.immersive-reader {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    overflow: hidden;
+    background: var(--theme-bg-main, #ffffff);
+    color: var(--theme-text, #252525);
+}
+
+.immersive-reader__scroll {
+    width: 100%;
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    outline: none;
+}
+
+.immersive-reader__page {
+    width: min(100%, 52rem);
+    min-height: 100%;
+    box-sizing: border-box;
+    margin: 0 auto;
+    padding: clamp(3rem, 10vh, 7rem) clamp(1.25rem, 5vw, 3.75rem) 7rem;
+}
+
+.immersive-reader__heading {
+    margin: 0 0 clamp(2.25rem, 6vh, 4rem);
+    text-align: center;
+
+    h1 {
+        margin: 0;
+        color: var(--theme-text, #252525);
+        font-family: Georgia, 'Times New Roman', serif;
+        font-size: clamp(1.7rem, 3.5vw, 2.45rem);
+        font-weight: 600;
+        letter-spacing: -0.025em;
+        line-height: 1.2;
+    }
+}
+
+.immersive-reader__chapter {
+    margin-left: 0.35em;
+    color: var(--theme-text-soft, #747474);
+    font-weight: 400;
+}
+
+.immersive-reader__verses {
+    font-family: Georgia, 'Times New Roman', serif;
+}
+
+.immersive-reader__verse {
+    margin: 0 0 1.25rem;
+    color: var(--theme-text, #252525);
+    font-size: clamp(1.08rem, 1.6vw, 1.32rem);
+    line-height: 1.9;
+}
+
+.immersive-reader__verse-number {
+    display: inline-block;
+    min-width: 1.65em;
+    margin-right: 0.25em;
+    color: var(--theme-text-soft, #747474);
+    font-size: 0.64em;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 1;
+    text-align: right;
+    vertical-align: 0.38em;
+}
+
+.immersive-reader__verse-text {
+    white-space: pre-wrap;
+}
+
+.immersive-reader__status {
+    margin: 4rem auto 0;
+    color: var(--theme-text-soft, #747474);
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1.1rem;
+    text-align: center;
+}
+
+.immersive-reader__shortcuts {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+}
+
+.immersive-reader__shortcut {
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.42rem;
+    box-sizing: border-box;
+    padding: 0.32rem 0.45rem;
+    border: 1px solid var(--theme-border, rgba(90, 90, 90, 0.2));
+    border-radius: 0.55rem;
+    background: color-mix(in srgb, var(--theme-bg-elevated, #ffffff) 92%, transparent);
+    box-shadow: 0 0.45rem 1.4rem rgba(0, 0, 0, 0.12);
+    color: var(--theme-text, #252525);
+    font-family: inherit;
+    font-size: 0.72rem;
+    line-height: 1.2;
+    white-space: nowrap;
+    backdrop-filter: blur(12px);
+}
+
+.immersive-reader__shortcut--exit {
+    top: 1.25rem;
+    left: 1.25rem;
+}
+
+.immersive-reader__shortcut--font {
+    top: 1.25rem;
+    right: 1.25rem;
+}
+
+.immersive-reader__shortcut--previous {
+    top: 50%;
+    left: 1.25rem;
+    transform: translateY(-50%);
+}
+
+.immersive-reader__shortcut--next {
+    top: 50%;
+    right: 1.25rem;
+    transform: translateY(-50%);
+}
+
+.immersive-reader__shortcut--scroll,
+.immersive-reader__shortcut--range {
+    bottom: 1.25rem;
+}
+
+.immersive-reader__shortcut--scroll {
+    left: 50%;
+    transform: translateX(calc(-100% - 0.35rem));
+}
+
+.immersive-reader__shortcut--range {
+    left: 50%;
+    transform: translateX(0.35rem);
+}
+
+.immersive-reader__keys {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.18rem;
+}
+
+.immersive-reader__key {
+    display: inline-flex;
+    min-width: 1.55rem;
+    height: 1.45rem;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 0.1rem 0.28rem;
+    border: 1px solid var(--theme-border, rgba(90, 90, 90, 0.28));
+    border-bottom-width: 2px;
+    border-radius: 0.35rem;
+    background: color-mix(in srgb, var(--theme-bg-main, #ffffff) 82%, var(--theme-text, #252525));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    color: var(--theme-text, #252525);
+    font-family: inherit;
+    font-size: 0.68rem;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+}
+
+.immersive-reader__key--wide {
+    min-width: 2.6rem;
+    font-size: 0.61rem;
+}
+
+.immersive-reader__shortcut-label {
+    color: var(--theme-text-soft, #747474);
+    font-weight: 600;
+}
+
+.immersive-reader__shortcuts-hint {
+    position: absolute;
+    bottom: 0.35rem;
+    left: 50%;
+    margin: 0;
+    transform: translateX(-50%);
+    color: var(--theme-text-soft, #747474);
+    font-size: 0.62rem;
+    text-align: center;
+    white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+    .immersive-reader__shortcut {
+        gap: 0.3rem;
+        padding: 0.27rem 0.35rem;
+        font-size: 0.66rem;
+    }
+
+    .immersive-reader__shortcut--exit {
+        top: 0.75rem;
+        left: 0.75rem;
+    }
+
+    .immersive-reader__shortcut--font {
+        top: 0.75rem;
+        right: 0.75rem;
+    }
+
+    .immersive-reader__shortcut--previous {
+        left: 0.55rem;
+    }
+
+    .immersive-reader__shortcut--next {
+        right: 0.55rem;
+    }
+
+    .immersive-reader__shortcut--previous .immersive-reader__shortcut-label,
+    .immersive-reader__shortcut--next .immersive-reader__shortcut-label {
+        display: none;
+    }
+
+    .immersive-reader__shortcut--scroll {
+        left: 0.75rem;
+        transform: none;
+    }
+
+    .immersive-reader__shortcut--range {
+        right: 0.75rem;
+        left: auto;
+        transform: none;
+    }
+
+    .immersive-reader__shortcuts-hint {
+        bottom: 0.2rem;
+        max-width: calc(100vw - 1.5rem);
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .immersive-reader__key {
+        min-width: 1.4rem;
+        height: 1.35rem;
+        font-size: 0.64rem;
+    }
+
+    .immersive-reader__key--wide {
+        min-width: 2.25rem;
+        font-size: 0.56rem;
+    }
+}
+
+@media (max-width: 380px) {
+    .immersive-reader__shortcut--exit,
+    .immersive-reader__shortcut--font {
+        top: 0.5rem;
+    }
+
+    .immersive-reader__shortcut--exit {
+        left: 0.45rem;
+    }
+
+    .immersive-reader__shortcut--font {
+        right: 0.45rem;
+    }
+
+    .immersive-reader__shortcut--scroll {
+        left: 0.45rem;
+    }
+
+    .immersive-reader__shortcut--range {
+        right: 0.45rem;
+    }
+
+    .immersive-reader__shortcut-label {
+        max-width: 3.3rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .immersive-reader__shortcuts-hint {
+        display: none;
+    }
+}
+</style>

--- a/FrontEndApp/src/Views/ReadBible/ViewVerses/ViewVerses.vue
+++ b/FrontEndApp/src/Views/ReadBible/ViewVerses/ViewVerses.vue
@@ -25,6 +25,7 @@ import PiperModelsModal from '../../../components/Settings/VerseReader/PiperMode
 import FootnotePopover from '../../../components/FootnotePopover/FootnotePopover.vue';
 import StrongsPopover from '../../../components/StrongsPopover/StrongsPopover.vue';
 import { useFlipbookStore } from '../../../store/flipbookStore';
+import { useImmersiveReaderStore } from '../../../store/immersiveReaderStore';
 import { useModuleStore } from '../../../store/moduleStore';
 import { Splitpanes, Pane } from 'splitpanes';
 
@@ -49,6 +50,8 @@ const piperStore = usePiperTTSStore();
 const settingStore = useSettingStore();
 const mainStore = useMainStore();
 const flipbookStore = useFlipbookStore();
+const immersiveReaderStore = useImmersiveReaderStore();
+const isElectron = Boolean(window.isElectron);
 
 const moduleStore = useModuleStore();
 
@@ -973,6 +976,18 @@ onUnmounted(() => {
                 >
                     <template #icon>
                         <Icon icon="mdi:book-open-page-variant" style="font-size: 24px" />
+                    </template>
+                </NButton>
+                <NButton
+                    v-if="isElectron"
+                    size="small"
+                    quaternary
+                    class="flex-shrink-0 mr-4px"
+                    title="Open immersive reader"
+                    @click="immersiveReaderStore.open()"
+                >
+                    <template #icon>
+                        <Icon icon="lucide:focus" style="font-size: 22px" />
                     </template>
                 </NButton>
                 <NButton

--- a/FrontEndApp/src/store/immersiveReaderStore.ts
+++ b/FrontEndApp/src/store/immersiveReaderStore.ts
@@ -1,0 +1,205 @@
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+import { getBibleService } from '../services/BibleService';
+import { useBibleStore } from './BibleStore';
+import { useSettingStore } from './settingStore';
+import { bibleBooks, type BookInfo } from '../util/books';
+import { stripVerseHtml } from '../util/helper';
+
+export type ImmersiveChapterDirection = 'next' | 'prev';
+
+export interface ImmersiveVerse {
+    verse: number;
+    text: string;
+}
+
+const DEFAULT_FONT_SIZE = 18;
+const MIN_FONT_SIZE = 12;
+const MAX_FONT_SIZE = 36;
+
+function chapterCount(book: BookInfo, showDeuterocanonical: boolean): number {
+    if (showDeuterocanonical && book.deuterocanonical_chapter_count) {
+        return book.deuterocanonical_chapter_count;
+    }
+    return book.chapter_count;
+}
+
+function normalizeVerses(result: any): ImmersiveVerse[] {
+    if (!Array.isArray(result)) return [];
+
+    return result
+        .filter((row) => row && Number.isFinite(Number(row.verse)))
+        .map((row) => ({
+            verse: Number(row.verse),
+            text: stripVerseHtml(String(row.version?.[0]?.text ?? '')),
+        }))
+        .filter((row) => row.text.length > 0);
+}
+
+export const useImmersiveReaderStore = defineStore('immersiveReader', () => {
+    const bibleStore = useBibleStore();
+    const settingStore = useSettingStore();
+
+    const isOpen = ref(false);
+    const isLoading = ref(false);
+    const loadError = ref(false);
+    const verses = ref<ImmersiveVerse[]>([]);
+    const activeBookNumber = ref(0);
+    const activeChapter = ref(1);
+    const selectedVersion = ref('');
+    const fontSize = ref(DEFAULT_FONT_SIZE);
+
+    const bookTitle = computed(() => {
+        return bibleBooks.find((book) => book.book_number === activeBookNumber.value)?.title ?? '';
+    });
+    const chapterNumber = computed(() => activeChapter.value);
+
+    let requestId = 0;
+    let windowModeRequest = Promise.resolve();
+
+    function requestImmersiveWindowMode(enabled: boolean) {
+        if (
+            typeof window === 'undefined' ||
+            !window.isElectron ||
+            typeof window.browserWindow?.setImmersiveWindowMode !== 'function'
+        ) {
+            return;
+        }
+
+        // Keep rapid open/close/re-open transitions ordered without making
+        // the reading surface depend on native window IPC succeeding.
+        windowModeRequest = windowModeRequest
+            .catch(() => undefined)
+            .then(() => window.browserWindow.setImmersiveWindowMode(enabled))
+            .catch(() => undefined);
+    }
+
+    function visibleBooks(): BookInfo[] {
+        return bibleBooks.filter(
+            (book) => settingStore.showDeuterocanonical || !book.deuterocanonical,
+        );
+    }
+
+    async function loadChapter(bookNumber: number, chapter: number, version: string) {
+        const currentRequest = ++requestId;
+        activeBookNumber.value = bookNumber;
+        activeChapter.value = chapter;
+        verses.value = [];
+        loadError.value = false;
+        isLoading.value = true;
+
+        try {
+            const result = await getBibleService().getVerses({
+                bible_versions: version ? [version] : [],
+                book_number: bookNumber,
+                selected_chapter: chapter,
+            });
+
+            // A slower response from an earlier chapter must never replace the
+            // chapter most recently requested by the reader.
+            if (currentRequest !== requestId) return;
+            verses.value = normalizeVerses(result);
+        } catch {
+            if (currentRequest !== requestId) return;
+            verses.value = [];
+            loadError.value = true;
+        } finally {
+            if (currentRequest === requestId) isLoading.value = false;
+        }
+    }
+
+    async function open() {
+        // The immersive window is an Electron-only reading surface. The web
+        // bridge can expose a Bible API stub, but it must not open this mode.
+        if (typeof window === 'undefined' || !window.isElectron) return;
+
+        requestImmersiveWindowMode(true);
+
+        const version = bibleStore.selectedBibleVersions[0] ?? '';
+        const bookNumber = bibleStore.selectedBookNumber;
+        const chapter = bibleStore.selectedChapter;
+
+        selectedVersion.value = version;
+        isOpen.value = true;
+
+        // Do not send an empty version list to the Electron Bible service. Keep
+        // the overlay open with its normal quiet error state instead.
+        if (!version) {
+            requestId++;
+            activeBookNumber.value = bookNumber;
+            activeChapter.value = chapter;
+            verses.value = [];
+            isLoading.value = false;
+            loadError.value = true;
+            return;
+        }
+
+        await loadChapter(bookNumber, chapter, version);
+    }
+
+    function close() {
+        requestImmersiveWindowMode(false);
+        requestId++;
+        isOpen.value = false;
+        isLoading.value = false;
+        loadError.value = false;
+        verses.value = [];
+    }
+
+    async function navigateChapter(direction: ImmersiveChapterDirection) {
+        const books = visibleBooks();
+        const currentIndex = books.findIndex(
+            (book) => book.book_number === activeBookNumber.value,
+        );
+        if (currentIndex < 0) return;
+
+        const currentBook = books[currentIndex];
+        const currentLimit = chapterCount(currentBook, settingStore.showDeuterocanonical);
+        let nextBookNumber = activeBookNumber.value;
+        let nextChapter = activeChapter.value;
+
+        if (direction === 'next') {
+            if (activeChapter.value < currentLimit) {
+                nextChapter = activeChapter.value + 1;
+            } else if (currentIndex < books.length - 1) {
+                nextBookNumber = books[currentIndex + 1].book_number;
+                nextChapter = 1;
+            } else {
+                return;
+            }
+        } else if (activeChapter.value > 1) {
+            nextChapter = activeChapter.value - 1;
+        } else if (currentIndex > 0) {
+            const previousBook = books[currentIndex - 1];
+            nextBookNumber = previousBook.book_number;
+            nextChapter = chapterCount(previousBook, settingStore.showDeuterocanonical);
+        } else {
+            return;
+        }
+
+        await loadChapter(nextBookNumber, nextChapter, selectedVersion.value);
+    }
+
+    function adjustFontSize(delta: number) {
+        const numericDelta = Number(delta);
+        if (!Number.isFinite(numericDelta)) return;
+        fontSize.value = Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, fontSize.value + numericDelta));
+    }
+
+    return {
+        isOpen,
+        isLoading,
+        loadError,
+        verses,
+        activeBookNumber,
+        activeChapter,
+        chapterNumber,
+        bookTitle,
+        selectedVersion,
+        fontSize,
+        open,
+        close,
+        navigateChapter,
+        adjustFontSize,
+    };
+});

--- a/FrontEndApp/src/util/webBridge.ts
+++ b/FrontEndApp/src/util/webBridge.ts
@@ -187,6 +187,7 @@ const stub: Window['browserWindow'] = {
     onWindowMaximized: () => { warnOnce('onWindowMaximized'); },
     getAppScale: async () => 1,
     setAppScale: async (scale: number) => scale,
+    setImmersiveWindowMode: async () => { /* no-op on web — immersive mode is Electron-only */ },
     appReady: () => { /* no-op on web — no splash window */ },
     setSplashTheme: async () => { /* no-op on web — no splash window */ },
 


### PR DESCRIPTION
## Summary

Adds a separate, Electron-only immersive reading experience focused entirely on Scripture.

- Opens from a new focus button in the Bible reader
- Displays only the book/chapter heading, verse numbers, and Scripture text
- Uses keyboard-only navigation:
  - Left/Right: previous or next chapter
  - Up/Down: scroll
  - Home/End: beginning or end
  - +/-: adjust text size
  - Esc: exit
- Reveals contextual `<kbd>` shortcut keycaps only while holding Ctrl/Cmd
- Supports continuous scrolling without entering OS fullscreen
- Temporarily allows the Electron window to shrink to 360x500 while immersive mode is open
- Restores the normal window minimum when immersive mode closes

## Implementation

- Reuses the existing Bible service, current translation/chapter selection, HTML-stripping helper, and theme variables
- Keeps immersive reader state isolated in a small Pinia store
- Uses a full-window teleported overlay without changing the normal reading experience
- Adds narrowly scoped Electron IPC for temporary window sizing
- Leaves the web version unchanged

## Validation

- Root TypeScript check: `tsc --noEmit`
- Frontend TypeScript check: `vue-tsc --noEmit`
- Vite production build
- `git diff --check`
- Local Electron development launch and hot reload
